### PR TITLE
Add default value for semver environment variable SEMVER_PRE_PREFIX

### DIFF
--- a/vars/edgeXSetupEnvironment.groovy
+++ b/vars/edgeXSetupEnvironment.groovy
@@ -43,4 +43,7 @@ def call(vars) {
         def vmArch = sh(script: 'uname -m', returnStdout: true).trim()
         env.setProperty('ARCH', vmArch)
     }
+
+    // set default semver suffix mode to development
+    env.setProperty('SEMVER_PRE_PREFIX', 'dev')
 }


### PR DESCRIPTION
This sets the default value for the pre-releases to dev.

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>