### PR TITLE
Add system activity file mount to LFtools

### DIFF
--- a/vars/edgeXInfraShipLogs.groovy
+++ b/vars/edgeXInfraShipLogs.groovy
@@ -30,7 +30,7 @@ def call(body) {
     }
 
     // running this inside the lftools container to avoid the 1-3 minute install of lftools
-    docker.image("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:alpine").inside('-u 0:0') {
+    docker.image("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:alpine").inside('-u 0:0 -v /var/log/sa:/var/log/sa') {
         withEnv(["SERVER_ID=logs"]){
             configFileProvider([configFile(fileId: _logSettingsFile, variable: 'SETTINGS_FILE')]) {
                 echo 'Running global-jjb/create-netrc.sh'


### PR DESCRIPTION
The edgeXInfraShipLogs global library needs to be updated in order to mount the system activity file from the host to the container running the lftools log publisher.  The lftools log publisher image now contains the sar utility and due to poor exception handling with the lftools logs deploy function it throws an exception and fails with "Cannot open /var/log/sa/sa13: No such file or directory" error.

@ernestojeda @jamesrgregg @lranjbar 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>