### PR TITLE
Pass env variable into edgeXDockerLogin and update edgeXBuildDocker unit tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -8,6 +8,7 @@ If you are running behind a proxy, then you will need to bind mount the settings
 docker container run \
 --rm \
 --env PROXY_HOST="--specify-your-proxy-server-hostname-here--" \
+--env PROXY_PORT="--specify-your-proxy-server-port-here--" \
 -it \
 -v $(pwd):/edgex-global-pipelines \
 -v $(pwd)/test/settings.xml:/root/.m2/settings.xml \

--- a/test/edgeXBuildDockerSpec.groovy
+++ b/test/edgeXBuildDockerSpec.groovy
@@ -53,6 +53,10 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     dockerTags: ['MyTag1', 'MyTag2'],
                     dockerBuildArgs: ['MyArg1', 'MyArg2']
 
+                ], [
+                    project: 'MyProject',
+                    releaseBranchOverride: 'golang'
+
                 ]
             ]
             expectedResult << [
@@ -84,6 +88,20 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     DOCKER_CUSTOM_TAGS: 'MyTag1 MyTag2',
                     DOCKER_BUILD_ARGS: 'MyArg1,MyArg2',
                     SEMVER_BUMP_LEVEL: 'pre'
+                ], [
+                    MAVEN_SETTINGS: 'MyProject-settings',
+                    PROJECT: 'MyProject',
+                    USE_SEMVER: false,
+                    DOCKER_FILE_PATH: 'Dockerfile',
+                    DOCKER_BUILD_CONTEXT: '.',
+                    DOCKER_IMAGE_NAME: 'docker-MyProject',
+                    DOCKER_REGISTRY_NAMESPACE: '',
+                    DOCKER_NEXUS_REPO: 'staging',
+                    PUSH_DOCKER_IMAGE: true,
+                    ARCHIVE_IMAGE: false,
+                    ARCHIVE_NAME: 'MyProject-archive.tar.gz',
+                    SEMVER_BUMP_LEVEL: 'pre',
+                    RELEASE_BRANCH_OVERRIDE: 'golang'
                 ]
             ]
     }

--- a/test/settings.xml
+++ b/test/settings.xml
@@ -5,7 +5,7 @@
       <active>true</active>
       <protocol>http</protocol>
       <host>${env.PROXY_HOST}</host>
-      <port>911</port>
+      <port>${env.PROXY_PORT}</port>
     </proxy>
  </proxies>
 </settings>

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -86,7 +86,7 @@ def call(config) {
 
                                 steps {
                                     script {
-                                        edgeXDockerLogin()
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         edgeXDocker.push("${DOCKER_IMAGE_NAME}", true, "${DOCKER_NEXUS_REPO}")
                                     }
                                 }
@@ -178,7 +178,7 @@ def call(config) {
 
                                 steps {
                                     script {
-                                        edgeXDockerLogin()
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         edgeXDocker.push("${DOCKER_IMAGE_NAME}-${ARCH}", true, "${DOCKER_NEXUS_REPO}")
                                     }
                                 }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -102,7 +102,7 @@ def call(config) {
 
                                 steps {
                                     script {
-                                        edgeXDockerLogin()
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         edgeXDocker.push("${DOCKER_IMAGE_NAME}", true, "${DOCKER_NEXUS_REPO}")
                                     }
                                 }
@@ -178,7 +178,7 @@ def call(config) {
 
                                 steps {
                                     script {
-                                        edgeXDockerLogin()
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         edgeXDocker.push("${DOCKER_IMAGE_NAME}-${ARCH}", true, "${DOCKER_NEXUS_REPO}")
                                     }
                                 }


### PR DESCRIPTION
- Fixing a bug where we aren't passing the maven settings environment variable into edgeXDockerLogin
- Also updating the unit tests for edgeXBuildDocker to include the new parameter releaseBranchOverride.
- Parameterized the port for the unit tests

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>