### PR TITLE
Update isReleaseStream to match exact names and add unit tests

### DIFF
--- a/test/edgeXBuildGoAppSpec.groovy
+++ b/test/edgeXBuildGoAppSpec.groovy
@@ -117,7 +117,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     TEST_SCRIPT: 'make test',
                     BUILD_SCRIPT: 'make build',
                     GO_VERSION: '1.12',
-                    DOCKER_BASE_IMAGE: 'nexus3.edgexfoundry.org:10003/edgex-golang-base:1.12.6-alpine',
+                    DOCKER_BASE_IMAGE: 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.12.14-alpine',
                     DOCKER_FILE_PATH: 'Dockerfile',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',

--- a/test/edgexSpec.groovy
+++ b/test/edgexSpec.groovy
@@ -12,32 +12,37 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
         explicitlyMockPipelineVariable('out')
     }
 
-    def "Test isReleaseStream [Should] return expected [When] called with branchName" () {
-        expect:
-            edgeX.isReleaseStream(branchName: branchName) == expectedResult
+    def "Test isReleaseStream [Should] return expected [When] called in production" () {
+        setup:
+            edgeX.getBinding().setVariable('env', [SILO: 'production'])
 
-        where:
-            branchName << [
-                'master',
-                'origin/master',
-                'california',
-                'delhi',
-                'edinburgh',
-                'fuji',
-                'test'
-            ]
-            expectedResult << [
-                true,
-                true,
-                true,
-                true,
-                true,
-                true,
-                false
-            ]
+        expect:
+            edgeX.isReleaseStream('master') == true
+            edgeX.isReleaseStream('california') == true
+            edgeX.isReleaseStream('delhi') == true
+            edgeX.isReleaseStream('edinburgh') == true
+            edgeX.isReleaseStream('fuji') == true
+            edgeX.isReleaseStream('xyzmaster') == false
+            edgeX.isReleaseStream('masterxyz') == false
+            edgeX.isReleaseStream('xyzmasterxyz') == false
     }
 
-    def "Test isReleaseStream [Should] return expected [When] called without branchName" () {
+    def "Test isReleaseStream [Should] return expected [When] called in non-production" () {
+        setup:
+            edgeX.getBinding().setVariable('env', [SILO: 'sandbox'])
+
+        expect:
+            edgeX.isReleaseStream('master') == false
+            edgeX.isReleaseStream('california') == false
+            edgeX.isReleaseStream('delhi') == false
+            edgeX.isReleaseStream('edinburgh') == false
+            edgeX.isReleaseStream('fuji') == false
+            edgeX.isReleaseStream('xyzmaster') == false
+            edgeX.isReleaseStream('masterxyz') == false
+            edgeX.isReleaseStream('xyzmasterxyz') == false
+    }
+
+    def "Test isReleaseStream [Should] return expected [When] called without branchName in production" () {
         setup:
             edgeX.getBinding().setVariable('env', [GIT_BRANCH: 'us5375'])
 

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -16,8 +16,7 @@
 
 def isReleaseStream(branchName = env.GIT_BRANCH) {
     // what defines a main release branch
-    def releaseStreams = [/master/, /california/, /delhi/, /edinburgh/, /fuji/]
-
+    def releaseStreams = [/^master$/, /^california$/, /^delhi$/, /^edinburgh$/, /^fuji$/]
     env.SILO == 'production' && (branchName && (releaseStreams.collect { branchName =~ it ? true : false }).contains(true))
 }
 


### PR DESCRIPTION
- Updated isReleaseStream to match branch names exactly.
- Added unit tests for isReleaseStream
- Updated failing unit test for edgeXBuildGoApp

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>