### PR TITLE
Update prepBaseBuildImage to handle arm golang image name correctly

### DIFF
--- a/test/edgeXBuildGoAppSpec.groovy
+++ b/test/edgeXBuildGoAppSpec.groovy
@@ -42,14 +42,14 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [
                 'ARCH': 'arm64',
-                'DOCKER_REGISTRY': 'MyDockerRegistry',
+                'DOCKER_REGISTRY': 'nexus3.edgexfoundry.org',
                 'http_proxy': 'MyHttpProxy',
-                'DOCKER_BASE_IMAGE': 'MyDockerRegistry/MyDockerBaseImage'
+                'DOCKER_BASE_IMAGE': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.12.14-alpine'
             ]
             edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
             explicitlyMockPipelineVariable('docker')
             edgeXBuildGoApp.getBinding().setVariable('ARCH', 'arm64')
-            edgeXBuildGoApp.getBinding().setVariable('DOCKER_BASE_IMAGE', 'MyDockerRegistry/MyDockerBaseImage')
+            edgeXBuildGoApp.getBinding().setVariable('DOCKER_BASE_IMAGE', 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.12.14-alpine')
             edgeXBuildGoApp.getBinding().setVariable('DOCKER_BUILD_FILE_PATH', 'MyDockerBuildFilePath')
             edgeXBuildGoApp.getBinding().setVariable('DOCKER_BUILD_CONTEXT', 'MyDockerBuildContext')
         when:
@@ -57,7 +57,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
         then:
             1 * getPipelineMock('docker.build').call([
                     'ci-base-image-arm64', 
-                    '-f MyDockerBuildFilePath  --build-arg BASE=MyDockerRegistry/MyDockerBaseImage-arm64 --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
+                    '-f MyDockerBuildFilePath  --build-arg BASE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base-arm64:1.12.14-alpine --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
     }
 
     def "Test validate [Should] raise error [When] config does not include a project parameter" () {

--- a/test/edgeXSnykSpec.groovy
+++ b/test/edgeXSnykSpec.groovy
@@ -21,7 +21,22 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSnyk()
         then:
-            1 * getPipelineMock('sh').call('snyk monitor')
+            1 * getPipelineMock('sh').call('snyk monitor --org=edgex-jenkins')
+    }
+
+    def "Test edgeXSnyk [Should] call snyk monitor without options [When] called with no arguments when SNYK_ORG" () {
+        setup:
+            def environmentVariables = [
+                'WORKSPACE': 'MyWorkspace',
+                'SNYK_ORG': 'MySnykOrg'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            explicitlyMockPipelineVariable('docker')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk()
+        then:
+            1 * getPipelineMock('sh').call('snyk monitor --org=MySnykOrg')
     }
 
     def "Test edgeXSnyk [Should] call snyk monitor with docker options [When] called with dockerImage and dockerFile arguments" () {
@@ -35,7 +50,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSnyk('MyDockerImage', 'MyDockerFile')
         then:
-            1 * getPipelineMock('sh').call('snyk monitor --docker MyDockerImage --file=./MyDockerFile')
+            1 * getPipelineMock('sh').call('snyk monitor --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile')
     }
 
     def "Test edgeXSnyk [Should] provide the expected arguments to the snyk docker image [When] called" () {

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -264,7 +264,7 @@ def prepBaseBuildImage() {
     def baseImage = env.DOCKER_BASE_IMAGE
 
     if(env.ARCH == 'arm64' && baseImage.contains(env.DOCKER_REGISTRY)) {
-        baseImage = "${DOCKER_BASE_IMAGE}-${ARCH}"
+        baseImage = "${DOCKER_BASE_IMAGE}".replace('edgex-golang-base', "edgex-golang-base-${ARCH}")
     }
 
     edgex.bannerMessage "[edgeXBuildGoApp] Building Code With image [${baseImage}]"


### PR DESCRIPTION
- Fixed issue with edgeXBuildGoApp referencing of ARM image
- Added unit tests for prepBaseBuildImage
- Fixed failing unit tests for edgeXSnyk

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>