### PR TITLE
Add unit test stage to build automation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,19 @@ pipeline {
             }
         }
 
+        stage('Test') {
+            when { expression { !edgex.isReleaseStream() } }
+            agent {
+                docker {
+                    image "${env.DOCKER_REGISTRY}:10003/edgex-devops/egp-unit-test:latest"
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'mvn clean test'
+            }
+        }
+
         stage('Semver Tag') {
             when { expression { edgex.isReleaseStream() } }
             steps {


### PR DESCRIPTION
- Added a Test stage to execute **edgex-global-pipelines** unit tests leveraging the egp-unit-test ci build image. The test stage will only execute on Pull Requests and not merges.

**Observations**:

- The new Test stage adds approximately 3-4 minutes to the total build time. 
- I noticed that testing iterates over all dependencies and downloads something small (just a few KB). I'm not sure what its downloading, the dependencies have been pre-downloaded into the build image. We can potentially shave another minute if we pre-bake whatever its downloading for each dependency. I'll investigate but that work will not affect this PR, if anything it will require changes to the egp-unit-test ci build image. 

Resolves #58 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>