### PR TITLE
add beforeAgent to eval when before the agent spins up

### DIFF
--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -52,8 +52,11 @@ def call(config) {
             stage('Build Docker Image') {
                 parallel {
                     stage('amd64') {
-                        when { expression { edgex.nodeExists(config, 'amd64') } }
-                        agent { label edgex.getNode(config, 'amd64') } // agent gets evaluated before when
+                        when {
+                            beforeAgent true
+                            expression { edgex.nodeExists(config, 'amd64') }
+                        }
+                        // agent { label edgex.getNode(config, 'amd64') } // comment out to reuse mainNode
                         environment {
                             ARCH = 'x86_64'
                         }
@@ -112,7 +115,10 @@ def call(config) {
                     }
 
                     stage('arm64') {
-                        when { expression { edgex.nodeExists(config, 'arm64') } }
+                        when {
+                            beforeAgent true
+                            expression { edgex.nodeExists(config, 'arm64') }
+                        }
                         agent { label edgex.getNode(config, 'arm64') }
                         environment {
                             ARCH = 'arm64'

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -25,7 +25,12 @@ def call(config) {
     ///////////////////////////////////////////////////////////////////////////
 
     pipeline {
-        agent { label edgex.mainNode(config) }
+        agent {
+            node {
+                label edgex.mainNode(config)
+                customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
+            }
+        }
         options {
             timestamps()
             preserveStashes()
@@ -51,13 +56,16 @@ def call(config) {
             stage('Build') {
                 parallel {
                     stage('amd64') {
-                        when { expression { edgex.nodeExists(config, 'amd64') } }
-                        agent {
+                        when {
+                            beforeAgent true
+                            expression { edgex.nodeExists(config, 'amd64') }
+                        }
+                        /*agent { // comment out to reuse mainNode
                             node {
                                 label edgex.getNode(config, 'amd64')
                                 customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
                             }
-                        }
+                        }*/
                         environment {
                             ARCH = 'x86_64'
                         }
@@ -115,7 +123,10 @@ def call(config) {
                     }
 
                     stage('arm64') {
-                        when { expression { edgex.nodeExists(config, 'arm64') } }
+                        when {
+                            beforeAgent true
+                            expression { edgex.nodeExists(config, 'arm64') }
+                        }
                         agent {
                             node {
                                 label edgex.getNode(config, 'arm64')

--- a/vars/edgeXGeneric.groovy
+++ b/vars/edgeXGeneric.groovy
@@ -68,8 +68,11 @@ def call(config) {
             stage('Build') {
                 parallel {
                     stage('amd64') {
-                        when { expression { edgex.nodeExists(config, 'amd64') } }
-                        agent { label edgex.getNode(config, 'amd64') }
+                        when {
+                            beforeAgent true
+                            expression { edgex.nodeExists(config, 'amd64') }
+                        }
+                        // agent { label edgex.getNode(config, 'amd64') }
                         environment {
                             ARCH = 'x86_64'
                             GOARCH = 'amd64'
@@ -147,7 +150,10 @@ def call(config) {
                         }
                     }
                     stage('arm64') {
-                        when { expression { edgex.nodeExists(config, 'arm64') } }
+                        when {
+                            beforeAgent true
+                            expression { edgex.nodeExists(config, 'arm64') }
+                        }
                         agent { label edgex.getNode(config, 'arm64') }
                         environment {
                             ARCH = 'arm64'


### PR DESCRIPTION
Also commented out the amd64 agent inside the parallel stage due to the fact the the originating node is already an amd64 agent and can be reused.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>