### PR TITLE
enable extra agent call in parallel amd64 stage

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -28,7 +28,6 @@ def call(config) {
         agent {
             node {
                 label edgex.mainNode(config)
-                customWorkspace "/w/workspace/${config.project}/${env.BUILD_ID}"
             }
         }
         options {
@@ -60,12 +59,12 @@ def call(config) {
                             beforeAgent true
                             expression { edgex.nodeExists(config, 'amd64') }
                         }
-                        /*agent { // comment out to reuse mainNode
+                        agent { // comment out to reuse mainNode
                             node {
                                 label edgex.getNode(config, 'amd64')
                                 customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
                             }
-                        }*/
+                        }
                         environment {
                             ARCH = 'x86_64'
                         }


### PR DESCRIPTION
This is to fix potential permissions issues caused by un-stashing the coverage report from the testing stage. Issue seems intermittent as other builds have passed without any issue. However, I am reverting to this logic as we haven't had permissions issues in the past. I will look into a different approach to prevent this issue in the future.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>