### PR TITLE
add config.credentials to be provided to the pipeline

### DIFF
--- a/vars/edgeXGeneric.groovy
+++ b/vars/edgeXGeneric.groovy
@@ -1,7 +1,8 @@
 import com.cloudbees.groovy.cps.NonCPS
 /*edgeXGeneric([
     project: 'edgex-go',
-    mavenSettings: ['edgex-go-codecov-token:CODECOV_TOKEN'],
+    mavenSettings: ['edgex-go-codecov-token:CODECOV_TOKEN'], (optional)
+    credentials: [string(credentialsId: 'credential-id-here', variable: 'APIKEY')], (optional)
     env: [
         GOPATH: '/opt/go-custom/go'
     ],
@@ -91,15 +92,19 @@ def call(config) {
                                 when { expression { anyScript(config, 'pre_build', env.GIT_BRANCH) } }
                                 steps {
                                     script {
-                                        configFileProvider(cfgAmd64) {
-                                            withEnv(["PATH=${setupPath(config)}"]) {
-                                                def scripts = allScripts(config, 'pre_build', env.GIT_BRANCH)
-                                                println "$ARCH pre_build: ${scripts}"
-                                                scripts.each { userScript ->
-                                                    if(userScript.indexOf('shell/') == 0) {
-                                                        sh "./.ci-management/${userScript}"
-                                                    } else {
-                                                        sh userScript
+                                        println "[DEBUG] creds ==============> ${config.credentials}"
+
+                                        withCredentials(config.credentials) {
+                                            configFileProvider(cfgAmd64) {
+                                                withEnv(["PATH=${setupPath(config)}"]) {
+                                                    def scripts = allScripts(config, 'pre_build', env.GIT_BRANCH)
+                                                    println "$ARCH pre_build: ${scripts}"
+                                                    scripts.each { userScript ->
+                                                        if(userScript.indexOf('shell/') == 0) {
+                                                            sh "./.ci-management/${userScript}"
+                                                        } else {
+                                                            sh userScript
+                                                        }
                                                     }
                                                 }
                                             }
@@ -111,15 +116,17 @@ def call(config) {
                                 when { expression { anyScript(config, 'build', env.GIT_BRANCH) } }
                                 steps {
                                     script {
-                                        configFileProvider(cfgAmd64) {
-                                            withEnv(["PATH=${setupPath(config)}"]) {
-                                                def scripts = allScripts(config, 'build', env.GIT_BRANCH)
-                                                println "$ARCH build: ${scripts}"
-                                                scripts.each { userScript ->
-                                                    if(userScript.indexOf('shell/') == 0) {
-                                                        sh "./.ci-management/${userScript}"
-                                                    } else {
-                                                        sh userScript
+                                        withCredentials(config.credentials) {
+                                            configFileProvider(cfgAmd64) {
+                                                withEnv(["PATH=${setupPath(config)}"]) {
+                                                    def scripts = allScripts(config, 'build', env.GIT_BRANCH)
+                                                    println "$ARCH build: ${scripts}"
+                                                    scripts.each { userScript ->
+                                                        if(userScript.indexOf('shell/') == 0) {
+                                                            sh "./.ci-management/${userScript}"
+                                                        } else {
+                                                            sh userScript
+                                                        }
                                                     }
                                                 }
                                             }
@@ -131,15 +138,17 @@ def call(config) {
                                 when { expression { anyScript(config, 'post_build', env.GIT_BRANCH) } }
                                 steps {
                                     script {
-                                        configFileProvider(cfgAmd64) {
-                                            withEnv(["PATH=${setupPath(config)}"]) {
-                                                def scripts = allScripts(config, 'post_build', env.GIT_BRANCH)
-                                                println "$ARCH post_build: ${scripts}"
-                                                scripts.each { userScript ->
-                                                    if(userScript.indexOf('shell/') == 0) {
-                                                        sh "./.ci-management/${userScript}"
-                                                    } else {
-                                                        sh userScript
+                                        withCredentials(config.credentials) {
+                                            configFileProvider(cfgAmd64) {
+                                                withEnv(["PATH=${setupPath(config)}"]) {
+                                                    def scripts = allScripts(config, 'post_build', env.GIT_BRANCH)
+                                                    println "$ARCH post_build: ${scripts}"
+                                                    scripts.each { userScript ->
+                                                        if(userScript.indexOf('shell/') == 0) {
+                                                            sh "./.ci-management/${userScript}"
+                                                        } else {
+                                                            sh userScript
+                                                        }
                                                     }
                                                 }
                                             }
@@ -173,15 +182,17 @@ def call(config) {
                                 when { expression { anyScript(config, 'pre_build', env.GIT_BRANCH) } }
                                 steps {
                                     script {
-                                        configFileProvider(cfgArm64) {
-                                            withEnv(["PATH=${setupPath(config)}"]) {
-                                                def scripts = allScripts(config, 'pre_build', env.GIT_BRANCH)
-                                                println "$ARCH pre_build: ${scripts}"
-                                                scripts.each { userScript ->
-                                                    if(userScript.indexOf('shell/') == 0) {
-                                                        sh "./.ci-management/${userScript}"
-                                                    } else {
-                                                        sh userScript
+                                        withCredentials(config.credentials) {
+                                            configFileProvider(cfgArm64) {
+                                                withEnv(["PATH=${setupPath(config)}"]) {
+                                                    def scripts = allScripts(config, 'pre_build', env.GIT_BRANCH)
+                                                    println "$ARCH pre_build: ${scripts}"
+                                                    scripts.each { userScript ->
+                                                        if(userScript.indexOf('shell/') == 0) {
+                                                            sh "./.ci-management/${userScript}"
+                                                        } else {
+                                                            sh userScript
+                                                        }
                                                     }
                                                 }
                                             }
@@ -193,15 +204,17 @@ def call(config) {
                                 when { expression { anyScript(config, 'build', env.GIT_BRANCH) } }
                                 steps {
                                     script {
-                                        configFileProvider(cfgArm64) {
-                                            withEnv(["PATH=${setupPath(config)}"]) {
-                                                def scripts = allScripts(config, 'build', env.GIT_BRANCH)
-                                                println "$ARCH build: ${scripts}"
-                                                scripts.each { userScript ->
-                                                    if(userScript.indexOf('shell/') == 0) {
-                                                        sh "./.ci-management/${userScript}"
-                                                    } else {
-                                                        sh userScript
+                                        withCredentials(config.credentials) {
+                                            configFileProvider(cfgArm64) {
+                                                withEnv(["PATH=${setupPath(config)}"]) {
+                                                    def scripts = allScripts(config, 'build', env.GIT_BRANCH)
+                                                    println "$ARCH build: ${scripts}"
+                                                    scripts.each { userScript ->
+                                                        if(userScript.indexOf('shell/') == 0) {
+                                                            sh "./.ci-management/${userScript}"
+                                                        } else {
+                                                            sh userScript
+                                                        }
                                                     }
                                                 }
                                             }
@@ -213,15 +226,17 @@ def call(config) {
                                 when { expression { anyScript(config, 'post_build', env.GIT_BRANCH) } }
                                 steps {
                                     script {
-                                        configFileProvider(cfgArm64) {
-                                            withEnv(["PATH=${setupPath(config)}"]) {
-                                                def scripts = allScripts(config, 'post_build', env.GIT_BRANCH)
-                                                println "$ARCH post_build: ${scripts}"
-                                                scripts.each { userScript ->
-                                                    if(userScript.indexOf('shell/') == 0) {
-                                                        sh "./.ci-management/${userScript}"
-                                                    } else {
-                                                        sh userScript
+                                        withCredentials(config.credentials) {
+                                            configFileProvider(cfgArm64) {
+                                                withEnv(["PATH=${setupPath(config)}"]) {
+                                                    def scripts = allScripts(config, 'post_build', env.GIT_BRANCH)
+                                                    println "$ARCH post_build: ${scripts}"
+                                                    scripts.each { userScript ->
+                                                        if(userScript.indexOf('shell/') == 0) {
+                                                            sh "./.ci-management/${userScript}"
+                                                        } else {
+                                                            sh userScript
+                                                        }
                                                     }
                                                 }
                                             }
@@ -268,6 +283,11 @@ def call(config) {
 def validate(config) {
     if(!config.project) {
         error('[edgeXGeneric] The parameter "project" is required. This is typically the project name.')
+    }
+
+    // set default credentials if empty or null
+    if(!config.credentials) {
+        config.credentials = []
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to the `edgeXGeneric` pipeline to allow the user to provide an array of credentials to the underlying `pre_build`, `build` and `post_build` stages of the pipeline.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Added labels

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Sandbox Testing
Test Links : N/A. Need to merge into master in order to test on the sandbox

## Other information
