### PR TITLE
fix issue with nexus GIT_COMMIT tagged images

### DIFF
--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -213,11 +213,11 @@ def call(config) {
                     script {
                         if(edgex.nodeExists(config, 'amd64')) {
                             def amd64Image = edgeXDocker.finalImageName("${DOCKER_IMAGE_NAME}")
-                            edgeXClair("${DOCKER_REGISTRY}/${amd64Image}:${GIT_COMMIT}")
+                            edgeXClair("${DOCKER_REGISTRY}/${amd64Image}:latest")
                         }
                         if(edgex.nodeExists(config, 'arm64')) {
                             def arm64Image = edgeXDocker.finalImageName("${DOCKER_IMAGE_NAME}-arm64")
-                            edgeXClair("${DOCKER_REGISTRY}/${arm64Image}:${GIT_COMMIT}")
+                            edgeXClair("${DOCKER_REGISTRY}/${arm64Image}:latest")
                         }
                     }
                 }


### PR DESCRIPTION
Currently there seems to be an issue with clair scanning images tagged with just the GIT_COMMIT hash. Since we always tag with `latest` in this pipeline, I am switch Clair to scan that tag.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
