### PR TITLE
update label to ubuntu18.04-docker-arm64-4c-16g

### DIFF
--- a/test/edgexSpec.groovy
+++ b/test/edgexSpec.groovy
@@ -247,7 +247,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
                         arch: 'amd64',
                         isDefault: true
                     ], [
-                        label: 'ubuntu18.04-docker-arm64-4c-2g',
+                        label: 'ubuntu18.04-docker-arm64-4c-16g',
                         arch: 'arm64',
                         isDefault: false
                     ]

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -74,7 +74,7 @@ def getNode(config, arch) {
 def setupNodes(config) {
     def defaultNodes = [
         [label: 'centos7-docker-4c-2g', arch: 'amd64', isDefault: true],
-        [label: 'ubuntu18.04-docker-arm64-4c-2g', arch: 'arm64', isDefault: false]
+        [label: 'ubuntu18.04-docker-arm64-4c-16g', arch: 'arm64', isDefault: false]
     ]
 
     def _arch = config.arch ?: ['amd64', 'arm64']


### PR DESCRIPTION
After this change: edgexfoundry/ci-management#584 the ARM64 label need to be updated to match.

Signed-off-by: Ernesto Ojeda ernesto.ojeda@intel.com

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
