### PR TITLE
Update ci-build-image references to refer to the appropriate nexus location

### DIFF
--- a/test/edgeXClairSpec.groovy
+++ b/test/edgeXClairSpec.groovy
@@ -35,7 +35,7 @@ public class EdgeXClairSpec extends JenkinsPipelineSpecification {
             explicitlyMockPipelineStep('withEnv')
             explicitlyMockPipelineStep('readJSON')
             explicitlyMockPipelineVariable('docker')
-            getPipelineMock('docker.image')('MyDockerRegistry:10003/edgex-klar:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('MyDockerRegistry:10003/edgex-devops/edgex-klar:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
             getPipelineMock('sh').call([script:'/klar MyDockerImage:MyTag | tee', returnStdout:true]) >> 'KlarOutput\n'
             getPipelineMock('readJSON').call([text:'KlarOutput']) >> 'KlarJsonOutput'
 

--- a/test/edgeXSemverSpec.groovy
+++ b/test/edgeXSemverSpec.groovy
@@ -23,7 +23,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
             edgeXSemver()
         then:
             1 * getPipelineMock('env.getProperty').call('GITSEMVER_HEAD_TAG') >> 'GitsemverHeadTag'
-            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgexfoundry/git-semver:latest-x86_64') >> explicitlyMockPipelineVariable('DockerImageMock')
+            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
             1 * getPipelineMock('sh')([script: 'git semver', returnStdout: true]) >> 'GitSemverVersion\n'
             // 1 * getPipelineMock('env.setProperty')('VERSION', '--version--')
             // noExceptionThrown()

--- a/test/edgeXSnykSpec.groovy
+++ b/test/edgeXSnykSpec.groovy
@@ -17,7 +17,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
             explicitlyMockPipelineVariable('docker')
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk()
         then:
@@ -32,7 +32,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
             explicitlyMockPipelineVariable('docker')
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk()
         then:
@@ -46,7 +46,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
             explicitlyMockPipelineVariable('docker')
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk('MyDockerImage', 'MyDockerFile')
         then:
@@ -60,7 +60,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
             explicitlyMockPipelineVariable('docker')
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk('MyDockerImage', 'MyDockerFile')
         then:

--- a/vars/edgeXClair.groovy
+++ b/vars/edgeXClair.groovy
@@ -19,7 +19,7 @@
    JSON Output: edgeXClair('dockerImage:tag', [outputFormat: 'json'])
 */
 def call(image, Map options = [:]) {
-    def klarImage = options.klarImage ?: "${env.DOCKER_REGISTRY}:10003/edgex-klar:latest"
+    def klarImage = options.klarImage ?: "${env.DOCKER_REGISTRY}:10003/edgex-devops/edgex-klar:latest"
     def server    = options.server    ?: 'clair-alb-414217221.us-west-2.elb.amazonaws.com:6060'
     
     if(!image) {

--- a/vars/edgeXSemver.groovy
+++ b/vars/edgeXSemver.groovy
@@ -15,9 +15,8 @@
 //
 
 def call(command = null, credentials = 'edgex-jenkins-ssh', debug = true) {
-    def arch = env.ARCH ?: 'x86_64'
     def gitSemverVersion = 'latest'
-    def semverImage = "nexus3.edgexfoundry.org:10004/edgexfoundry/git-semver:${gitSemverVersion}-${arch}"
+    def semverImage = "nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:${gitSemverVersion}"
     def envVars = [
         'SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts'
     ]

--- a/vars/edgeXSnyk.groovy
+++ b/vars/edgeXSnyk.groovy
@@ -15,7 +15,7 @@
 //
 
 def call(dockerImage = null, dockerFile = null) {
-    def snykImage = 'nexus3.edgexfoundry.org:10003/edgex-snyk-go:1.217.3'
+    def snykImage = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3'
     def org = env.SNYK_ORG ?: 'edgex-jenkins'
 
     // Run snyk monitor by default


### PR DESCRIPTION
The respective ci-build-image references were updated to refer to the appropriate nexus location. The following table provides an overview of all ci-build-images and which ones required updating.

| CI Build Image | Status |
| --- | --- |
| edgex-docs-builder | No references found |
| edgex-gcc-base | Existing references did not require updating |
| edgex-golang-base | Existing references did not require updating |
| edgex-jmeter | No references found |
| edgex-jq | No references found |
| **edgex-klar** | **References were updated** |
| edgex-newman | No references found |
| **edgex-snyk-go** | **References were updated** |
| edgex-sonarqube | No references found |
| edgex-unit-test | Existing references did not require updating |
| robotframeworko | No references found |
| **git-semver** | **References were updated** |

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X]  The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/edgex-global-pipelines/issues/118

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information

- The git-semver application is currently building and publishing an x86_64 image and arm64 image to Nexus, however only the x86* image is consumed. We need to update the git-semver build to only build and publish the x86* image.
- Git-semver is currently publishing its builds to Nexus Staging all other CI build images publish to Nexus Snapshots.  For consistency-sake, we should consider updating the Git-semver build to publish to Nexus Snapshots instead of Nexus Staging.