### PR TITLE
Add releaseBranch parameter to edgexRelease.collectReleaseYamlFiles

### DIFF
--- a/test/edgeXReleaseSpec.groovy
+++ b/test/edgeXReleaseSpec.groovy
@@ -13,8 +13,8 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
     def "Test collectReleaseYamlFiles [Should] return instance of java.util.ArrayList of size 2 [When] called with no parameters and two changed files" () {
         setup:
             getPipelineMock('findFiles').call([glob:'release/*.yaml']) >> ['app-functions-sdk-go.yaml', 'edgex-go.yaml']
-            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml') >> true
-            getPipelineMock('edgex.didChange').call('edgex-go.yaml') >> true
+            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml', 'release') >> true
+            getPipelineMock('edgex.didChange').call('edgex-go.yaml', 'release') >> true
             getPipelineMock('readYaml').call([file:'app-functions-sdk-go.yaml']) >> [
                     name:'app-functions-sdk-go', 
                     version:'v1.2.0', 
@@ -80,8 +80,8 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
     def "Test collectReleaseYamlFiles [Should] return instance of java.util.ArrayList of size 1 [When] called with no parameters and one changed file" () {
         setup:
             getPipelineMock('findFiles').call([glob:'release/*.yaml']) >> ['app-functions-sdk-go.yaml', 'edgex-go.yaml']
-            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml') >> true
-            getPipelineMock('edgex.didChange').call('edgex-go.yaml') >> false
+            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml', 'release') >> true
+            getPipelineMock('edgex.didChange').call('edgex-go.yaml', 'release') >> false
             getPipelineMock('readYaml').call([file:'app-functions-sdk-go.yaml']) >> [
                     name:'app-functions-sdk-go', 
                     version:'v1.2.0', 
@@ -133,8 +133,8 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
     def "Test collectReleaseYamlFiles [Should] return instance of java.util.ArrayList of size 0 [When] called with no parameters and no changed files" () {
         setup:
             getPipelineMock('findFiles').call([glob:'release/*.yaml']) >> ['app-functions-sdk-go.yaml', 'edgex-go.yaml']
-            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml') >> false
-            getPipelineMock('edgex.didChange').call('edgex-go.yaml') >> false
+            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml', 'release') >> false
+            getPipelineMock('edgex.didChange').call('edgex-go.yaml', 'release') >> false
             getPipelineMock('readYaml').call([file:'app-functions-sdk-go.yaml']) >> [
                     name:'app-functions-sdk-go', 
                     version:'v1.2.0', 
@@ -211,8 +211,8 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
     def "Test collectReleaseYamlFiles [Should] return instance of java.util.ArrayList of size 2 [When] called with a filepath parameter and two changed files" () {
         setup:
             getPipelineMock('findFiles').call([glob:'fuji/*.yaml']) >> ['app-functions-sdk-go.yaml', 'edgex-go.yaml']
-            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml') >> true
-            getPipelineMock('edgex.didChange').call('edgex-go.yaml') >> true
+            getPipelineMock('edgex.didChange').call('app-functions-sdk-go.yaml', 'release') >> true
+            getPipelineMock('edgex.didChange').call('edgex-go.yaml', 'release') >> true
             getPipelineMock('readYaml').call([file:'app-functions-sdk-go.yaml']) >> [
                     name:'app-functions-sdk-go', 
                     version:'v1.2.0', 

--- a/vars/edgeXRelease.groovy
+++ b/vars/edgeXRelease.groovy
@@ -14,12 +14,12 @@
 // limitations under the License.
 //
 
-def collectReleaseYamlFiles(filePath = 'release/*.yaml') {
+def collectReleaseYamlFiles(filePath = 'release/*.yaml', releaseBranch = 'release') {
     def releaseData = []
     def yamlFiles = findFiles(glob: filePath)
 
     for (f in yamlFiles) {
-        if (edgex.didChange(f.toString())) {
+        if (edgex.didChange(f.toString(), releaseBranch)) {
             releaseData << readYaml(file: f.toString())
         }   
     }


### PR DESCRIPTION
Adding this parameter to be able to override the branch in didChange().
The default value of 'origin/master' causes issues because in cd-management we will not be committing to the master branch.

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
