### PR TITLE
Implemented EdgeXReleaseGitTag function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,15 @@ test {
   reports {
     junitXml.enabled = true
   }
+
+  // prints a summary after test execution
+  testLogging {
+    afterSuite { desc, result ->
+      if (!desc.parent) {
+        println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+      }
+    }
+  }
 }
 
 jacocoTestReport {
@@ -120,4 +129,3 @@ task printClasspath {
     configurations.testRuntimeClasspath.each { println it }
   }
 }
-

--- a/src/test/groovy/edgeXReleaseGitTagSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagSpec.groovy
@@ -4,15 +4,159 @@ import spock.lang.Ignore
 public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
     
     def edgeXReleaseGitTag = null
+    def validReleaseInfo
+
+    public static class TestException extends RuntimeException {
+        public TestException(String _message) { 
+            super( _message );
+        }
+    }
 
     def setup() {
         edgeXReleaseGitTag = loadPipelineScriptForTest('vars/edgeXReleaseGitTag.groovy')
         explicitlyMockPipelineVariable('out')
+        validReleaseInfo = [
+            'name': 'sample-service',
+            'version': '1.2.3',
+            'releaseStream': 'master',
+            'repo': 'https://github.com/edgexfoundry/sample-service.git'
+        ]
     }
 
-    @Ignore
-    def "Test edgeXReleaseGitTag [Should] return [When] called " () {
-        
+    def "Test validate [Should] raise error [When] release info yaml does not have a name attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseGitTag.validate(validReleaseInfo.findAll {it.key != 'name'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'name\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a version attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseGitTag.validate(validReleaseInfo.findAll {it.key != 'version'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'version\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a releaseStream attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseGitTag.validate(validReleaseInfo.findAll {it.key != 'releaseStream'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'releaseStream\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a repo attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseGitTag.validate(validReleaseInfo.findAll {it.key != 'repo'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'repo\'')
+    }
+
+    def "Test getSSHRepoName [Should] return expected #expectedResult [When] called" () {
+        setup:
+        expect:
+            edgeXReleaseGitTag.getSSHRepoName(repo) == expectedResult
+        where:
+            repo << [
+                'https://github.com/edgexfoundry/sample-service.git',
+                'git@github.com:edgexfoundry/sample-service.git',
+                'https://github.com/edgexfoundry/edgex-go.git',
+                'https://github.com/edgexfoundry/device-sdk-go.git',
+                'https://github.com/edgexfoundry/app-functions-sdk-go.git'
+            ]
+            expectedResult << [
+                'git@github.com:edgexfoundry/sample-service.git',
+                'git@github.com:edgexfoundry/sample-service.git',
+                'git@github.com:edgexfoundry/edgex-go.git',
+                'git@github.com:edgexfoundry/device-sdk-go.git',
+                'git@github.com:edgexfoundry/app-functions-sdk-go.git'
+            ]
+    }
+
+    def "Test cloneRepo [Should] call sh and sshagent with expected arguments [When] called" () {
+        setup:
+            explicitlyMockPipelineStep('sshagent')
+        when:
+            edgeXReleaseGitTag.cloneRepo('https://github.com/edgexfoundry/sample-service.git', 'master', 'sample-service', 'MyCredentials')
+        then:
+            1 * getPipelineMock('sshagent').call(_) >> { _arguments ->
+                assert ['credentials':['MyCredentials']] == _arguments[0][0]
+            }
+            1 * getPipelineMock('sh').call('git clone -b master git@github.com:edgexfoundry/sample-service.git sample-service')
+            1 * getPipelineMock('sh').call('cd sample-service')
+    }
+
+    def "Test setGitTag [Should] call edgeXSemver init, tag and push with expected arguments [When] called" () {
+        setup:
+            explicitlyMockPipelineStep('edgeXSemver')
+        when:
+            edgeXReleaseGitTag.setGitTag('sample-service', '1.2.3')
+        then:
+            1 * getPipelineMock('edgeXSemver').call('init -ver=1.2.3 -force')
+            1 * getPipelineMock('edgeXSemver').call('tag -force')
+            1 * getPipelineMock('edgeXSemver').call('push')
+    }
+
+    def "Test signGitTag [Should] call edgeXInfraLFToolsSign with expected arguments [When] called" () {
+        setup:
+            explicitlyMockPipelineStep('edgeXInfraLFToolsSign')
+        when:
+            edgeXReleaseGitTag.signGitTag('1.2.3')
+        then:
+            1 * getPipelineMock('edgeXInfraLFToolsSign').call([command: 'git-tag', version: 'v1.2.3'])
+    }
+
+    def "Test releaseGitTag [Should] catch and echo exception message [When] exception occurs" () {
+        setup:
+            explicitlyMockPipelineVariable('echo')
+            // TODO: figure out how to properly stub cloneRepo to set side-effect Exception
+            // explicitlyMockPipelineVariable('cloneRepo')
+            // getPipelineMock('cloneRepo').call(_) >> {
+            //     throw new Exception('Clone Repository Exception')
+            // }           
+            explicitlyMockPipelineStep('sshagent')
+            getPipelineMock('sshagent')(_) >> {
+                throw new Exception('SSH Exception')
+            }
+        when:
+            edgeXReleaseGitTag.releaseGitTag(validReleaseInfo, 'MyCredentials')
+        then:
+            1 * getPipelineMock('echo.call')('[edgeXReleaseGitTag]: ERROR occurred releasing git tag: java.lang.Exception: SSH Exception')
+    }
+
+    def "Test edgeXReleaseGitTag [Should] not throw error [When] called with valid release info" () {
+        setup:
+            explicitlyMockPipelineVariable('echo')
+            explicitlyMockPipelineStep('sshagent')
+            explicitlyMockPipelineStep('edgeXSemver')
+            explicitlyMockPipelineStep('edgeXInfraLFToolsSign')
+        when:
+            edgeXReleaseGitTag(validReleaseInfo)
+        then:
+            noExceptionThrown()
     }
 
 }

--- a/vars/edgeXReleaseGitTag.groovy
+++ b/vars/edgeXReleaseGitTag.groovy
@@ -14,9 +14,78 @@
 // limitations under the License.
 //
 
-def call (config) {
+/*
 
-    sh "echo Git Tag Publish"
-    println "gitTagDestination: ${config.gitTagDestination}"
-    
+releaseYaml:
+
+---
+name: 'sample-service'
+version: 1.1.2
+releaseStream: master
+repo: 'https://github.com/edgexfoundry/sample-service.git'
+
+edgeXReleaseGitTag(releaseYaml)
+
+*/
+
+def call(releaseInfo, credentials = 'edgex-jenkins-ssh') {
+    validate(releaseInfo)
+    releaseGitTag(releaseInfo, credentials)
+}
+
+def validate(releaseInfo) {
+    // raise error if releaseInfo map does not contain required attributes
+    if(!releaseInfo.name) {
+        error("[edgeXReleaseGitTag]: Release yaml does not contain 'name'")
+    }
+    if(!releaseInfo.version) {
+        error("[edgeXReleaseGitTag]: Release yaml does not contain 'version'")
+    }
+    if(!releaseInfo.releaseStream) {
+        error("[edgeXReleaseGitTag]: Release yaml does not contain 'releaseStream'")
+    }
+    if(!releaseInfo.repo) {
+        error("[edgeXReleaseGitTag]: Release yaml does not contain 'repo'")
+    }
+}
+
+def getSSHRepoName(repo) {
+    // return git ssh address for http repo
+    repo.replaceAll("https://github.com/", "git@github.com:")
+}
+
+def cloneRepo(repo, branch, name, credentials) {
+    // clone the repo branch to name using the specified ssh credentials
+    def ssh_repo = getSSHRepoName(repo)
+    println "[edgeXReleaseGitTag]: git cloning ${ssh_repo} : ${branch} to ${name}"
+    sshagent(credentials: [credentials]) {
+        sh "git clone -b ${branch} ${ssh_repo} ${name}"
+        sh "cd ${name}"
+    }
+}
+
+def setGitTag(name, version) {
+    // call edgeXSemver functions to force tag version and push
+    println "[edgeXReleaseGitTag]: setting tag for ${name} to: ${version}"
+    edgeXSemver "init -ver=${version} -force"
+    edgeXSemver "tag -force"
+    edgeXSemver "push"
+}
+
+def signGitTag(version) {
+    // call edgeXInfraLFToolsSign to sign git tag version
+    println "[edgeXReleaseGitTag]: signing tag: v${version}"
+    edgeXInfraLFToolsSign(command: "git-tag", version: "v${version}")
+}
+
+def releaseGitTag(releaseInfo, credentials) {
+    // exception handled function that clones, sets and signs git tag version
+    try {
+        cloneRepo(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name, credentials)
+        setGitTag(releaseInfo.name, releaseInfo.version)
+        signGitTag(releaseInfo.version)
+    }
+    catch(error) {
+        echo("[edgeXReleaseGitTag]: ERROR occurred releasing git tag: ${error}")
+    }
 }


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Not Applicable.

## Are there any specific instructions or things that should be known prior to reviewing?

I am of the opinion that we can remove the `gitTagDestination` field from the release YAML definition, it is redundant and the `repo` field can be used to determine both the git repo as well as the tag destination.

## Other information

All code was unit tested:

```
# gradle clean test --tests EdgeXReleaseGitTagSpec

> Task :test
Results: SUCCESS (10 tests, 10 successes, 0 failures, 0 skipped)

BUILD SUCCESSFUL in 24s
5 actionable tasks: 5 executed
```
