### PR TITLE
add edgex-global-pipelines release tag information to main pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,9 +32,11 @@ pipeline {
     stages {
         stage('Prep') {
             steps {
-                edgeXSetupEnvironment()
-                edgeXSemver 'init'
                 script {
+                    //edgex.releaseInfo() this can be uncommented once this moves to stable
+                    edgeXSetupEnvironment()
+                    edgeXSemver 'init'
+
                     env.OG_VERSION = env.VERSION
                     sh "echo Archived original version: [$OG_VERSION]"
                 }

--- a/resources/releaseinfo.sh
+++ b/resources/releaseinfo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set +e #prevents exit of script due to command error
+tagsToDisplay="${EGP_TAG_VERSIONS:-stable experimental}"
+for tagSearch in $(echo $tagsToDisplay);
+do 
+    allTags=$(curl -s "https://api.github.com/repos/edgexfoundry/edgex-global-pipelines/git/refs/tags");
+    searchSha=$(echo "$allTags" | jq -r ".[] | select(.ref==\"refs/tags/${tagSearch}\") | .object.sha"); 
+    tagJson=$(curl -s "https://api.github.com/repos/edgexfoundry/edgex-global-pipelines/git/tags/${searchSha}"); 
+    tagger=$(echo $tagJson | tr -d '\n' | jq -r '.tagger.name + " " + .tagger.email'); 
+    message=$(echo $tagJson | tr -d '\n' | jq -r '.message'); 
+    commitSha=$(echo "$tagJson" | tr -d '\n' | jq -r '.object.sha') ; 
+    echo "$tagSearch info:\n-------------------\nCommited By: $tagger\nCommit SHA: $commitSha\nMessage: $message\n-------------------"; 
+done

--- a/resources/releaseinfo.sh
+++ b/resources/releaseinfo.sh
@@ -1,13 +1,32 @@
 #!/bin/bash
 set +e #prevents exit of script due to command error
+
+GH_BASE_URL=${GH_BASE_URL:-https://api.github.com}
+GH_TOKEN=${GH_TOKEN_PSW}
+
 tagsToDisplay="${EGP_TAG_VERSIONS:-stable experimental}"
-for tagSearch in $(echo $tagsToDisplay);
-do 
-    allTags=$(curl -s "https://api.github.com/repos/edgexfoundry/edgex-global-pipelines/git/refs/tags");
-    searchSha=$(echo "$allTags" | jq -r ".[] | select(.ref==\"refs/tags/${tagSearch}\") | .object.sha"); 
-    tagJson=$(curl -s "https://api.github.com/repos/edgexfoundry/edgex-global-pipelines/git/tags/${searchSha}"); 
-    tagger=$(echo $tagJson | tr -d '\n' | jq -r '.tagger.name + " " + .tagger.email'); 
-    message=$(echo $tagJson | tr -d '\n' | jq -r '.message'); 
-    commitSha=$(echo "$tagJson" | tr -d '\n' | jq -r '.object.sha') ; 
-    echo "$tagSearch info:\n-------------------\nCommited By: $tagger\nCommit SHA: $commitSha\nMessage: $message\n-------------------"; 
+for namedTag in $(echo $tagsToDisplay); do
+    allTags=$(curl -u "$GH_TOKEN:x-oauth-basic" -s "$GH_BASE_URL/repos/edgexfoundry/edgex-global-pipelines/git/refs/tags")
+
+    #find the named tag commit sha
+    searchSha=$(echo "$allTags" | jq -r ".[] | select(.ref==\"refs/tags/${namedTag}\") | .object.sha")
+    tagJson=$(curl -u "$GH_TOKEN:x-oauth-basic" -s "$GH_BASE_URL/repos/edgexfoundry/edgex-global-pipelines/git/tags/${searchSha}")
+
+    if [ "$(echo "$tagJson" | tr -d '\n' | jq -r '.message')" != "Not Found" ]; then
+    tagger=$(echo "$tagJson"    | tr -d '\n' | jq -r '.tagger.name + " " + .tagger.email')
+    message=$(echo "$tagJson"   | tr -d '\n' | jq -r '.message')
+    commitSha=$(echo "$tagJson" | tr -d '\n' | jq -r '.object.sha')
+
+    cat << EOF
+-------------------
+$namedTag info:
+-------------------
+Commited By: $tagger
+Commit SHA: $commitSha
+Message: $message
+EOF
+    else
+        echo '-------------------'
+        echo "No tag info for: $namedTag"
+    fi
 done

--- a/src/test/groovy/edgexSpec.groovy
+++ b/src/test/groovy/edgexSpec.groovy
@@ -349,4 +349,16 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
                 false
             ]
     }
+
+    // still working on a better test. right now just confirming the proper script is executed
+    def "Test releaseInfo [Should] run releaseinfo.sh shell script with [When] called" () {
+        setup:
+            explicitlyMockPipelineVariable('usernamePassword')
+            explicitlyMockPipelineVariable('withEnv')
+
+        when:
+            edgeX.releaseInfo()
+        then:
+            1 * getPipelineMock('sh').call(script: libraryResource('releaseinfo.sh'))
+    }
 }

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -44,6 +44,7 @@ def call(config) {
         stages {
             stage('Prepare') {
                 steps {
+                    script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
                 }
             }

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -45,6 +45,7 @@ def call(config) {
         stages {
             stage('Prepare') {
                 steps {
+                    script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
                 }
             }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -47,6 +47,7 @@ def call(config) {
         stages {
             stage('Prepare') {
                 steps {
+                    script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
                 }
             }

--- a/vars/edgeXGeneric.groovy
+++ b/vars/edgeXGeneric.groovy
@@ -52,6 +52,7 @@ def call(config) {
         stages {
             stage('Prepare') {
                 steps {
+                    script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
 
                     dir('.ci-management') {

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -20,6 +20,12 @@ def isReleaseStream(branchName = env.GIT_BRANCH) {
     env.SILO == 'production' && (branchName && (releaseStreams.collect { branchName =~ it ? true : false }).contains(true))
 }
 
+def releaseInfo(displayVersion='stable,experimental') {
+    withEnv(["DISPLAY_VERSION=${displayVersion}"]) {
+        sh(script: libraryResource('releaseinfo.sh'))
+    }
+}
+
 def didChange(expression, previous='origin/master') {
     // If there was no previous successful build (as in building for first time) will return true.
     def diffCount = 0

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -20,9 +20,13 @@ def isReleaseStream(branchName = env.GIT_BRANCH) {
     env.SILO == 'production' && (branchName && (releaseStreams.collect { branchName =~ it ? true : false }).contains(true))
 }
 
-def releaseInfo(displayVersion='stable,experimental') {
-    withEnv(["DISPLAY_VERSION=${displayVersion}"]) {
-        sh(script: libraryResource('releaseinfo.sh'))
+def releaseInfo(tagVersions='stable experimental') {
+    def credId = (env.SILO == 'production') ? 'edgex-jenkins-github-personal-access-token' : 'edgex-jenkins-access-username'
+    // these env var names are declararive syntax norms
+    withCredentials([usernamePassword(credentialsId: credId, usernameVariable: 'GH_TOKEN_USR', passwordVariable: 'GH_TOKEN_PSW')]) {
+        withEnv(["EGP_TAG_VERSIONS=${tagVersions}"]) {
+            sh(script: libraryResource('releaseinfo.sh'))
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
Currently it is unclear what semver version of edgex-global-pipelines is being used when looking directly at the Jenkins log output. The current tagging only shows either `stable` or `experimental` a separate lookup is required to track down what version `stable` or `experimental` point to.

## Solutiuon
This PR adds a new shell script `resources/releaseinfo.sh` that can be used to list tag information out to the Jenkins build log. By default it will print both the `stable` and `experimental` tag information out to the log. A GitHub personal access token `GH_TOKEN_PSW` is required to call the script to avoid rate limiting issues.

**Note**: This will have to be merged and moved to `experimental` in order to test the functionality. This cannot be tested on the sandbox without first merging.

## Functional Test Sample Output

Default invocation:

```Shell
$ export GH_TOKEN_PSW=xxxxxx
$ ./resources/releaseinfo.sh
-------------------
stable info:
-------------------
Commited By: Ernesto Ojeda ernesto.ojeda@intel.com
Commit SHA: 2c066709739fb3ad411965007f25d8ceb9ca6ba5
Message: update stable to v1.0.59
-------------------
experimental info:
-------------------
Commited By: edgex-jenkins collab-it+edgex@linuxfoundation.org
Commit SHA: 63abaa86d04c5bec44f642dc7c39b98174bcd9c9
Message: update experimental to v1.0.68
```

Override Default Tag Versions:

```Shell
$ export GH_TOKEN_PSW=xxxxxx
$ EGP_TAG_VERSIONS=stable ./resources/releaseinfo.sh
-------------------
stable info:
-------------------
Commited By: Ernesto Ojeda ernesto.ojeda@intel.com
Commit SHA: 2c066709739fb3ad411965007f25d8ceb9ca6ba5
Message: update stable to v1.0.59
```

Override Default Tag Versions with unknown tag:

```Shell
$ export GH_TOKEN_PSW=xxxxxx
$ EGP_TAG_VERSIONS=unknown ./resources/releaseinfo.sh
-------------------
No tag info for: unknown
```

The goal of the script is to only be as optional informational to the Jenkins log and never should fail the build in any way.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :
#131
