### PR TITLE
implement Snap stages for x86 and ARM

### DIFF
--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -120,6 +120,20 @@ def call(config) {
                                     }
                                 }
                             }
+
+                            /*stage('Snap') {
+                                when {
+                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                }
+                                steps {
+                                    script {
+                                        edgeXSnap(
+                                            jobType: edgex.isReleaseStream()
+                                                ? 'stage' : 'build'
+                                        )
+                                    }
+                                }
+                            }*/
                         }
                     }
 
@@ -185,6 +199,20 @@ def call(config) {
                                     }
                                 }
                             }
+
+                            /*stage('Snap') {
+                                when {
+                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                }
+                                steps {
+                                    script {
+                                        edgeXSnap(
+                                            jobType: edgex.isReleaseStream()
+                                                ? 'stage' : 'build'
+                                        )
+                                    }
+                                }
+                            }*/
                         }
                     }
                 }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -125,6 +125,20 @@ def call(config) {
                                     }
                                 }
                             }
+
+                            stage('Snap') {
+                                when {
+                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                }
+                                steps {
+                                    script {
+                                        edgeXSnap(
+                                            jobType: edgex.isReleaseStream()
+                                                ? 'stage' : 'build'
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -189,6 +203,20 @@ def call(config) {
                                     script {
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         taggedARM64Images = edgeXDocker.push("${DOCKER_IMAGE_NAME}-${ARCH}", true, "${DOCKER_NEXUS_REPO}")
+                                    }
+                                }
+                            }
+
+                            stage('Snap') {
+                                when {
+                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                }
+                                steps {
+                                    script {
+                                        edgeXSnap(
+                                            jobType: edgex.isReleaseStream()
+                                                ? 'stage' : 'build'
+                                        )
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

The following PR adds a new "Snap" stage for both x86 and ARM architectures. The stage is conditioned on whether a `snap/snapcraft.yaml` file exits. If it does, depending on if this is a PR or merge build it will either do a jobType 'build' or 'stage'. Due to these being declarative pipeline changes I did not add unit tests. However, I did functional tests on the LF sandbox to prove out similar code will work.

## Functional Tests

### Go

https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/device-modbus-go-snappy-snap/detail/device-modbus-go-snappy-snap/11/pipeline

### C

This one is a bit tricky because the current device-grove-c job I was testing with is broken. However, I did achieve the same broken result as the [existing job](https://jenkins.edgexfoundry.org/view/Snap/job/device-grove-c-snap-master-stage-snap/). This is why the code is commented.

https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/device-grove-c-snappy-snap/detail/device-grove-c-snappy-snap/1/pipeline

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#125 

## Are there any specific instructions or things that should be known prior to reviewing?

Current C build is broken and should be fixed before uncommenting out the code in `edgeXBuildCApp`
