### PR TITLE
Add option for snapChannel and buildSnap

### DIFF
--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -121,19 +121,22 @@ def call(config) {
                                 }
                             }
 
-                            /*stage('Snap') {
+                            stage('Snap') {
                                 when {
-                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    allOf {
+                                        environment name: 'BUILD_SNAP', value: 'true'
+                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    }
                                 }
                                 steps {
                                     script {
                                         edgeXSnap(
-                                            jobType: edgex.isReleaseStream()
-                                                ? 'stage' : 'build'
+                                            jobType: edgex.isReleaseStream() ? 'stage' : 'build',
+                                            snapChannel: env.SNAP_CHANNEL
                                         )
                                     }
                                 }
-                            }*/
+                            }
                         }
                     }
 
@@ -200,19 +203,22 @@ def call(config) {
                                 }
                             }
 
-                            /*stage('Snap') {
+                            stage('Snap') {
                                 when {
-                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    allOf {
+                                        environment name: 'BUILD_SNAP', value: 'true'
+                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    }
                                 }
                                 steps {
                                     script {
                                         edgeXSnap(
-                                            jobType: edgex.isReleaseStream()
-                                                ? 'stage' : 'build'
+                                            jobType: edgex.isReleaseStream() ? 'stage' : 'build',
+                                            snapChannel: env.SNAP_CHANNEL
                                         )
                                     }
                                 }
-                            }*/
+                            }
                         }
                     }
                 }
@@ -368,6 +374,8 @@ def toEnvironment(config) {
     def _buildImage          = edgex.defaultTrue(config.buildImage)
     def _pushImage           = edgex.defaultTrue(config.pushImage)
     def _semverBump          = config.semverBump ?: 'pre'
+    def _snapChannel         = config.snapChannel ?: 'latest/edge'
+    def _buildSnap           = edgex.defaultFalse(config.buildSnap)
 
     // no image to build, no image to push
     if(!_buildImage) {
@@ -389,7 +397,9 @@ def toEnvironment(config) {
         DOCKER_NEXUS_REPO: _dockerNexusRepo,
         BUILD_DOCKER_IMAGE: _buildImage,
         PUSH_DOCKER_IMAGE: _pushImage,
-        SEMVER_BUMP_LEVEL: _semverBump
+        SEMVER_BUMP_LEVEL: _semverBump,
+        SNAP_CHANNEL: _snapChannel,
+        BUILD_SNAP: _buildSnap
     ]
 
     edgex.bannerMessage "[edgeXBuildCApp] Pipeline Parameters:"

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -128,13 +128,16 @@ def call(config) {
 
                             stage('Snap') {
                                 when {
-                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    allOf {
+                                        environment name: 'BUILD_SNAP', value: 'true'
+                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    }
                                 }
                                 steps {
                                     script {
                                         edgeXSnap(
-                                            jobType: edgex.isReleaseStream()
-                                                ? 'stage' : 'build'
+                                            jobType: edgex.isReleaseStream() ? 'stage' : 'build',
+                                            snapChannel: env.SNAP_CHANNEL
                                         )
                                     }
                                 }
@@ -209,13 +212,16 @@ def call(config) {
 
                             stage('Snap') {
                                 when {
-                                    expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    allOf {
+                                        environment name: 'BUILD_SNAP', value: 'true'
+                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                    }
                                 }
                                 steps {
                                     script {
                                         edgeXSnap(
-                                            jobType: edgex.isReleaseStream()
-                                                ? 'stage' : 'build'
+                                            jobType: edgex.isReleaseStream() ? 'stage' : 'build',
+                                            snapChannel: env.SNAP_CHANNEL
                                         )
                                     }
                                 }
@@ -381,6 +387,8 @@ def toEnvironment(config) {
     def _pushImage           = edgex.defaultTrue(config.pushImage)
     def _semverBump          = config.semverBump ?: 'pre'
     def _goProxy             = config.goProxy ?: 'https://nexus3.edgexfoundry.org/repository/go-proxy/'
+    def _snapChannel         = config.snapChannel ?: 'latest/edge'
+    def _buildSnap           = edgex.defaultFalse(config.buildSnap)
 
     // no image to build, no image to push
     if(!_buildImage) {
@@ -404,7 +412,9 @@ def toEnvironment(config) {
         BUILD_DOCKER_IMAGE: _buildImage,
         PUSH_DOCKER_IMAGE: _pushImage,
         SEMVER_BUMP_LEVEL: _semverBump,
-        GOPROXY: _goProxy
+        GOPROXY: _goProxy,
+        SNAP_CHANNEL: _snapChannel,
+        BUILD_SNAP: _buildSnap
     ]
 
     edgex.bannerMessage "[edgeXBuildGoApp] Pipeline Parameters:"


### PR DESCRIPTION
Because of so many existing repos having snap build failures I added an option to make the snap stage optional. By default it is turned off unless the developer specifies `buildSnap: true` in the call to `edgeXBuildGoApp` or `edgeXBuildCApp`. I also added an option to override the snap channel because I saw some use of that in the wild for named branch releases.

I also updated tests to use actual edgex.groovy impl to get proper results

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe: