### PR TITLE
Implement EdgeXReleaseSnap function

### DIFF
--- a/src/test/groovy/edgeXReleaseSnapSpec.groovy
+++ b/src/test/groovy/edgeXReleaseSnapSpec.groovy
@@ -4,15 +4,342 @@ import spock.lang.Ignore
 public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     
     def edgeXReleaseSnap = null
+    def edgeX = null
+    def validReleaseInfo
+    def validSnapInfo
+
+    public static class TestException extends RuntimeException {
+        public TestException(String _message) { 
+            super( _message );
+        }
+    }
 
     def setup() {
         edgeXReleaseSnap = loadPipelineScriptForTest('vars/edgeXReleaseSnap.groovy')
+        edgeXReleaseSnap.getBinding().setVariable('edgex', {})
+        explicitlyMockPipelineStep('isDryRun')
         explicitlyMockPipelineVariable('out')
+        validReleaseInfo = [
+            'name': 'sample-service',
+            'version': '1.2.3',
+            'snap': true,
+            'repo': 'https://github.com/edgexfoundry/sample-service.git',
+            'releaseStream': 'master',
+            'snapChannels': [
+                [
+                    channel: 'latest/stable',
+                    revisionNumber: null
+                ], [
+                    channel: 'geneva/stable',
+                    revisionNumber: null
+                ]
+            ]
+        ]
+        validSnapInfo = [
+            "channel-map": [
+                [
+                    channel: [
+                        architecture:"amd64",
+                        name:"edge",
+                        "released-at":"2020-04-16T00:14:48.629377+00:00",
+                        risk:"edge",
+                        track:"latest"
+                    ],
+                    revision:"2211"
+                ], [
+                    channel: [
+                        architecture:"arm64",
+                        name:"edge",
+                        "released-at":"2020-04-16T00:14:48.629377+00:00",
+                        risk:"edge",
+                        track:"latest"
+                    ],
+                    revision:"2188"
+                ], [
+                    channel: [
+                        architecture:"amd64",
+                        name:"candidate",
+                        "released-at":"2020-04-16T00:14:48.629377+00:00",
+                        risk:"candidate",
+                        track:"latest"
+                    ],
+                    revision:"2049"
+                ]
+            ]
+        ]
     }
 
-    @Ignore
-    def "Test edgeXReleaseSnap [Should] return [When] called " () {
-        
+    def "Test validate [Should] raise error [When] release info yaml does not have a name attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'name'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'name\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a version attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'version'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'version\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a snapChannels attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'snapChannels'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'snapChannels\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a releaseStream attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'releaseStream'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'releaseStream\'')
+    }    
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a repo attribute" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+        when:
+            try {
+                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'repo'})
+            }
+            catch(TestException exception) {
+            }
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'repo\'')
+    }
+
+    def "Test getSnapcraftAddress [Should] return #expectedResult [When] when called" () {
+        setup:
+        expect:
+            edgeXReleaseSnap.getSnapcraftAddress(repo, branch) == expectedResult
+        where:
+            repo << [
+                'https://github.com/edgexfoundry/sample-service.git',
+                'git@github.com:edgexfoundry/sample-service.git',
+                'https://github.com/edgexfoundry/edgex-go',
+                'https://github.com/edgexfoundry/device-sdk-go.git',
+                'https://github.com/edgexfoundry/app-functions-sdk-go.git'
+            ]
+            branch << [
+                'master',
+                'fuji',
+                'master',
+                'branch1',
+                'branch2'
+            ]
+            expectedResult << [
+                'https://raw.githubusercontent.com/edgexfoundry/sample-service/master/snap/snapcraft.yaml',
+                'git@github.com:edgexfoundry/sample-service/fuji/snap/snapcraft.yaml',
+                'https://raw.githubusercontent.com/edgexfoundry/edgex-go/master/snap/snapcraft.yaml',
+                'https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/branch1/snap/snapcraft.yaml',
+                'https://raw.githubusercontent.com/edgexfoundry/app-functions-sdk-go/branch2/snap/snapcraft.yaml'
+            ]
+    }
+
+    def "Test getSnapMetadata [Should] call sh and readYaml with the expected arguments [When] called" () {
+        setup:
+            def environmentVariables = [
+                'WORKSPACE': '/w/thecars'
+            ]
+            edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
+        when:
+            edgeXReleaseSnap.getSnapMetadata("https://github.com/edgexfoundry/edgex-go", "master")
+        then:
+            1 * 
+            1 * getPipelineMock("readYaml").call(file: "/w/thecars/snapcraft.yaml")
+    }
+
+    def "Test getSnapInfo [Should] call sh with the expected arguments [When] called" () {
+        setup:
+        when:
+            edgeXReleaseSnap.getSnapInfo("edgexfoundry")
+        then:
+            1 * getPipelineMock("sh").call([
+                    script: "curl --fail -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/edgexfoundry?fields=name,revision'",
+                    returnStdout: true]) >> '{}'
+    }
+
+    def "Test getSnapRevision [Should] return expected revision [When] called" () {
+        setup:
+        expect:
+            expectedResult == edgeXReleaseSnap.getSnapRevision(validSnapInfo, architecture, trackName)
+        where:
+            trackName << [
+                'latest/edge',
+                'latest/edge',
+                'latest/candidate',
+                'latest/candidate'
+
+            ]
+            architecture << [
+                'amd64',
+                'arm64',
+                'amd64',
+                'arm64'
+            ]
+            expectedResult << [
+                '2211',
+                '2188',
+                '2049',
+                '1'
+            ]
+    }
+
+    def "Test releaseSnap [Should] catch and raise error [When] exception occurs" () {
+        setup:
+            explicitlyMockPipelineStep('error')
+            // TODO: figure out how to properly stub getSnapMetadata to set side-effect Exception
+            // explicitlyMockPipelineStep('getSnapMetadata')
+            // getPipelineMock('getSnapMetadata').call(_) >> {
+            //     throw new Exception('Get Snap Metadata Exception')
+            // }
+            def environmentVariables = [
+                'WORKSPACE': '/w/thecars'
+            ]
+            edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('sh').call('curl --fail -o /w/thecars/snapcraft.yaml -O https://raw.githubusercontent.com/edgexfoundry/sample-service/master/snap/snapcraft.yaml') >> {
+                throw new Exception('curl Exception')
+            }
+        when:
+            edgeXReleaseSnap.releaseSnap(validReleaseInfo)
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseSnap]: ERROR occurred releasing snap: java.lang.Exception: curl Exception')
+    }
+
+    def "Test releaseSnap [Should] call expected [When] DRY_RUN is true" () {
+        setup:
+            explicitlyMockPipelineStep('echo')
+            explicitlyMockPipelineStep('edgeXSnap')
+            explicitlyMockPipelineStep('withEnv')
+            def environmentVariables = [
+                'WORKSPACE': '/w/thecars',
+                'DRY_RUN': 'true'
+            ]
+            def archList = []
+            edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('isDryRun')() >> true
+            getPipelineMock('readYaml').call(file: '/w/thecars/snapcraft.yaml') >> [
+                name: 'sample-service',
+                architectures: [
+                    [
+                        'build-on':'arm64'
+                    ], [
+                        'build-on':'amd64'
+                    ], [
+                        'build-on':'armhf'
+                    ]
+                ]
+            ]
+            getPipelineMock('sh').call([
+                script: "curl --fail -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/sample-service?fields=name,revision'",
+                returnStdout: true]) >> ''
+            getPipelineMock('readJSON').call(text: _) >> validSnapInfo
+        when:
+            edgeXReleaseSnap.releaseSnap(validReleaseInfo)
+        then:
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: latest/stable, snapRevision: 2211, snapName: sample-service) - DRY_RUN: true")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: latest/stable, snapRevision: 2188, snapName: sample-service) - DRY_RUN: true")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: geneva/stable, snapRevision: 2211, snapName: sample-service) - DRY_RUN: true")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: geneva/stable, snapRevision: 2188, snapName: sample-service) - DRY_RUN: true")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: architecture armhf is not supported")
+            0 * getPipelineMock('edgeXSnap').call(_)
+            4 * getPipelineMock('withEnv').call(_) >> { _arguments ->
+                    archList << _arguments[0][0][0]
+                }
+            assert archList == ['ARCH=arm64', 'ARCH=arm64', 'ARCH=amd64', 'ARCH=amd64']
+            // TODO: figure out why the assertion below didn't work
+            // 2 * getPipelineMock('withEnv').call(_) >> { _arguments ->
+            //         def envArgs = [
+            //             'ARCH=arm64'
+            //         ]
+            //         assert envArgs == _arguments[0][0]
+            //     }
+    }
+
+    def "Test releaseSnap [Should] call expected [When] DRY_RUN is false" () {
+        setup:
+            explicitlyMockPipelineStep('echo')
+            explicitlyMockPipelineStep('edgeXSnap')
+            explicitlyMockPipelineStep('withEnv')
+            def environmentVariables = [
+                'WORKSPACE': '/w/thecars',
+                'DRY_RUN': 'false'
+            ]
+            def archList = []
+            edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('isDryRun')() >> false
+            getPipelineMock('readYaml').call(file: '/w/thecars/snapcraft.yaml') >> [
+                name: 'sample-service',
+                architectures: [
+                    [
+                        'build-on':'arm64'
+                    ], [
+                        'build-on':'amd64'
+                    ], [
+                        'build-on':'armhf'
+                    ]
+                ]
+            ]
+            getPipelineMock('sh').call([
+                script: "curl --fail -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/sample-service?fields=name,revision'",
+                returnStdout: true]) >> ''
+            getPipelineMock('readJSON').call(text: _) >> validSnapInfo
+            // URGH: was really hoping this would work based off how parseJson was mocked
+            // explicitlyMockPipelineStep('getSnapInfo')
+            // getPipelineMock('getSnapInfo')('sample-service') >> validSnapInfo
+        when:
+            edgeXReleaseSnap.releaseSnap(validReleaseInfo)
+        then:
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: architecture armhf is not supported")
+            1 * getPipelineMock('edgeXSnap').call([jobType: 'release', snapChannel: 'latest/stable', snapRevision: '2211', snapName: 'sample-service'])
+            1 * getPipelineMock('edgeXSnap').call([jobType: 'release', snapChannel: 'latest/stable', snapRevision: '2188', snapName: 'sample-service'])
+            1 * getPipelineMock('edgeXSnap').call([jobType: 'release', snapChannel: 'geneva/stable', snapRevision: '2211', snapName: 'sample-service'])
+            1 * getPipelineMock('edgeXSnap').call([jobType: 'release', snapChannel: 'geneva/stable', snapRevision: '2188', snapName: 'sample-service'])
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: latest/stable, snapRevision: 2211, snapName: sample-service) - DRY_RUN: false")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: latest/stable, snapRevision: 2188, snapName: sample-service) - DRY_RUN: false")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: geneva/stable, snapRevision: 2211, snapName: sample-service) - DRY_RUN: false")
+            1 * getPipelineMock('echo').call("[edgeXReleaseSnap]: edgeXSnap(jobType: 'release', snapChannel: geneva/stable, snapRevision: 2188, snapName: sample-service) - DRY_RUN: false")
+            4 * getPipelineMock('withEnv').call(_) >> { _arguments ->
+                    archList << _arguments[0][0][0]
+                }
+            assert archList == ['ARCH=arm64', 'ARCH=arm64', 'ARCH=amd64', 'ARCH=amd64']
+    }
+
+    def "Test edgeXReleaseSnap [Should] echo repo is not snap enabled [When] release info yaml snap is false" () {
+        setup:
+            explicitlyMockPipelineStep('echo')
+        when:
+            validReleaseInfo['snap'] = false
+            edgeXReleaseSnap(validReleaseInfo)
+            validReleaseInfo['snap'] = true
+        then:
+            1 * getPipelineMock('echo').call('[edgeXReleaseSnap]: repo is not snap enabled')
     }
 
 }

--- a/src/test/groovy/edgexSpec.groovy
+++ b/src/test/groovy/edgexSpec.groovy
@@ -363,4 +363,33 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
         then:
             1 * getPipelineMock('sh').call(script: libraryResource('releaseinfo.sh'))
     }
+
+    def "Test isDryRun [Should] return false [When] DRY_RUN has false values" () {
+        setup:
+            def values = [
+                '0',
+                'false',
+                'other'
+            ]           
+        expect:
+            values.each { value ->
+                edgeX.getBinding().setVariable('env', ['DRY_RUN': value])
+                edgeX.isDryRun() == false
+            }
+    }
+
+    def "Test isDryRun [Should] return true [When] DRY_RUN has true values" () {
+        setup:
+            def values = [
+                null,
+                '1',
+                'true'
+            ]           
+        expect:
+            values.each { value ->
+                edgeX.getBinding().setVariable('env', ['DRY_RUN': value])
+                edgeX.isDryRun() == true
+            }
+    }
+
 }

--- a/vars/edgeXReleaseSnap.groovy
+++ b/vars/edgeXReleaseSnap.groovy
@@ -14,9 +14,141 @@
 // limitations under the License.
 //
 
-def call (config) {
+/*
 
-    sh "echo Snap Publish"
-    println "snapChannel: ${config.snapChannel}"
-    
+releaseYaml:
+
+---
+name: 'sample-service'
+version: 1.1.2
+releaseStream: 'master'
+repo: 'https://github.com/edgexfoundry/sample-service.git'
+snapChannels:
+  - channel: 'latest/stable'
+    revisionNumber: 2218
+  - channel: 'geneva/stable'
+    revisionNumber: ~
+snap: true
+
+edgeXReleaseSnap(releaseYaml)
+
+*/
+
+def call(releaseInfo) {
+    if(releaseInfo.containsKey("snap")) {
+        if(releaseInfo["snap"]) {
+            validate(releaseInfo)
+            releaseSnap(releaseInfo)
+        }
+        else {
+            echo("[edgeXReleaseSnap]: repo is not snap enabled")
+        }
+    }
+}
+
+def validate(releaseInfo) {
+    // raise error if releaseInfo map does not contain required attributes
+    if(!releaseInfo.name) {
+        error("[edgeXReleaseSnap]: Release yaml does not contain 'name'")
+    }
+    if(!releaseInfo.version) {
+        error("[edgeXReleaseSnap]: Release yaml does not contain 'version'")
+    }
+    if(!releaseInfo.snapChannels) {
+        error("[edgeXReleaseSnap]: Release yaml does not contain 'snapChannels'")
+    }
+    if(!releaseInfo.releaseStream) {
+        error("[edgeXReleaseSnap]: Release yaml does not contain 'releaseStream'")
+    }
+    if(!releaseInfo.repo) {
+        error("[edgeXReleaseSnap]: Release yaml does not contain 'repo'")
+    }
+}
+
+def getSnapcraftAddress(repo, branch) {
+    // return the raw content address for snapcraft yaml
+    repo.replaceAll("\\.git", "").replaceAll("https://github.com/", "https://raw.githubusercontent.com/") + "/${branch}/snap/snapcraft.yaml"
+}
+
+def getSnapMetadata(repo, branch) {
+    // return snap meta data for repo
+    println "[edgeXReleaseSnap]: getting snap metadata for repo: ${repo} branch: ${branch}"
+    def snapCraftAddress = getSnapcraftAddress(repo, branch)
+    sh "curl --fail -o ${env.WORKSPACE}/snapcraft.yaml -O ${snapCraftAddress}"
+    readYaml(file: "${env.WORKSPACE}/snapcraft.yaml")
+}
+
+def getSnapInfo(snapName) {
+    // return info from snapcraft.io store for snapName
+    println "[edgeXReleaseSnap]: getting info from snapcraft for snapName: ${snapName}"
+    def snapInfoStdout = sh(
+        script: "curl --fail -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/${snapName}?fields=name,revision'",
+        returnStdout: true).trim()
+    readJSON(text: snapInfoStdout)
+}
+
+def getSnapRevision(snapInfo, architecture, trackName) {
+    // return revision within snapInfo that matches architecture and trackName
+    println "[edgeXReleaseSnap]: getting revison for trackName: ${trackName} architecture: ${architecture}"
+    def trackNameSplit = trackName.split('/')
+    def track = trackNameSplit[0]
+    def name = trackNameSplit[1]
+    def found = snapInfo.'channel-map'.find { item ->
+        (item.channel.architecture == architecture && item.channel.track == track && item.channel.name == name) 
+    }
+    if(found) {
+        return found.revision
+    }
+    else {
+        return '1'
+    }
+}
+
+def releaseSnap(releaseInfo) {
+    // exception handled function that releases snap
+    try {
+        println "[edgeXReleaseSnap]: releasing snaps for: ${releaseInfo.name}"
+        // get snap metadata from snapcraft.yaml located in the repo
+        def snapMetadata = getSnapMetadata(releaseInfo.repo, releaseInfo.releaseStream)
+        // get snap info from snapcraft.io store
+        def snapInfo = getSnapInfo(snapMetadata.name)
+        snapMetadata.architectures.each { architecture ->
+            if(['amd64', 'arm64'].contains(architecture.'build-on')) {
+                // edgeXSnap requires architecture to be set as environment variable
+                releaseInfo.snapChannels.each { snapChannel ->
+                    def snapRevision
+                    if(snapChannel.revisionNumber) {
+                        snapRevision = snapChannel.revisionNumber
+                    }
+                    else {
+                        // attempt to find revision that matches architecture for trackName
+                        // if no trackName specified default to 'latest/edge'
+                        def trackName = snapChannel.trackName ?: 'latest/edge'
+                        snapRevision = getSnapRevision(snapInfo, architecture.'build-on', trackName)
+                    }
+                    withEnv(["ARCH=${architecture.'build-on'}"]) {
+                        def message = """[edgeXReleaseSnap]:\
+                            edgeXSnap(jobType: 'release',\
+                                snapChannel: ${snapChannel.channel},\
+                                snapRevision: ${snapRevision},\
+                                snapName: ${snapMetadata.name}) - DRY_RUN: ${env.DRY_RUN}"""
+                        echo(message.replaceAll("\\s{2,}", " ").trim())
+                        if(!edgex.isDryRun()) {
+                            edgeXSnap([
+                                jobType: 'release',
+                                snapChannel: snapChannel.channel,
+                                snapRevision: snapRevision,
+                                snapName: snapMetadata.name])
+                        }
+                    }
+                }
+            }
+            else {
+                echo("[edgeXReleaseSnap]: architecture ${architecture.'build-on'} is not supported")
+            }
+        }
+    }
+    catch(Exception ex) {
+        error("[edgeXReleaseSnap]: ERROR occurred releasing snap: ${ex}")
+    }
 }

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -150,3 +150,8 @@ def releaseInfo(tagVersions='stable experimental') {
         }
     }
 }
+
+def isDryRun() {
+    // return True if DRY_RUN is set False otherwise
+    [null, '1', 'true'].contains(env.DRY_RUN)
+}


### PR DESCRIPTION
**EdgeXReleaseSnap** will be integrated into cd-management and be responsible for releasing snaps for all the snap-enabled EdgeX repos.

**Pseudo-Code**:
```
get snap metadata from github repo /snap/snapcraft.yaml (snapName & architectures)
get snap info from snapcraft.io store for the snapName (channelmap & revisions)
iterate over architectures defined for the given Snap
    if architecture is supported (amd64, arm64)
        iterate over snapChannels to be released
            set ARCH environment variable
            if no snapRevision is provided
                trackName is 'latest/edge' unless specified otherwise
                get snapRevision from snap info retreived from the snapcraft.io store that matches architecture and trackName
            call edgeXSnap
                jobType: 'release',
                snapChannel: snapChannel
                snapRevision: snapRevision
                snapName: snapName
```
**Snapcraft IO Info**
Snap Info for a given Snap was retrieved from snapcraft io store using the following endpoint:
```
curl --fail -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/${snapName}?fields=name,revision
```

**Pair-Programming Note**:
The code contained within the PR was produced via pair programming session with @bill-mahoney 

Signed-off-by: Emilio Reyes <emilio.reyes@.intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/cd-management/issues/3

## Sandbox Testing
The `edgeXReleaseSnap` DRY_RUN functionally was successfully tested in the Jenkins Sandbox environment.
Test Links :
[Test-edgeXReleaseSnap - Configuration](https://jenkins.edgexfoundry.org/sandbox/view/All/job/Test-edgeXReleaseSnap/configure)
[Test-edgeXReleaseSnap - Job Console](https://jenkins.edgexfoundry.org/sandbox/view/All/job/Test-edgeXReleaseSnap/55/console)

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
All functions added have corresponding unit tests:
```
# gradle clean test --tests EdgeXReleaseSnapSpec
> Task :test
Results: SUCCESS (13 tests, 13 successes, 0 failures, 0 skipped)

BUILD SUCCESSFUL in 3m 4s
5 actionable tasks: 5 executed
```
Verified all unit tests for all other functions continue to work:
```
# gradle clean test

> Task :test
Results: SUCCESS (144 tests, 141 successes, 0 failures, 3 skipped)

BUILD SUCCESSFUL in 2m 40s
5 actionable tasks: 5 executed
```
