### PR TITLE
Update to use explicit snapcraft filename

### DIFF
--- a/src/test/groovy/edgeXReleaseSnapSpec.groovy
+++ b/src/test/groovy/edgeXReleaseSnapSpec.groovy
@@ -169,10 +169,10 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
             ]
             edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
         when:
-            edgeXReleaseSnap.getSnapMetadata("https://github.com/edgexfoundry/edgex-go", "master")
+            edgeXReleaseSnap.getSnapMetadata("https://github.com/edgexfoundry/edgex-go", "master", "edgex-go")
         then:
-            1 * 
-            1 * getPipelineMock("readYaml").call(file: "/w/thecars/snapcraft.yaml")
+            1 * getPipelineMock("sh").call("curl --fail -o /w/thecars/snapcraft-edgex-go.yaml -O https://raw.githubusercontent.com/edgexfoundry/edgex-go/master/snap/snapcraft.yaml")
+            1 * getPipelineMock("readYaml").call(file: "/w/thecars/snapcraft-edgex-go.yaml")
     }
 
     def "Test getSnapInfo [Should] call sh with the expected arguments [When] called" () {
@@ -223,7 +223,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
                 'WORKSPACE': '/w/thecars'
             ]
             edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('sh').call('curl --fail -o /w/thecars/snapcraft.yaml -O https://raw.githubusercontent.com/edgexfoundry/sample-service/master/snap/snapcraft.yaml') >> {
+            getPipelineMock('sh').call('curl --fail -o /w/thecars/snapcraft-sample-service.yaml -O https://raw.githubusercontent.com/edgexfoundry/sample-service/master/snap/snapcraft.yaml') >> {
                 throw new Exception('curl Exception')
             }
         when:
@@ -244,7 +244,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
             def archList = []
             edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
             getPipelineMock('isDryRun')() >> true
-            getPipelineMock('readYaml').call(file: '/w/thecars/snapcraft.yaml') >> [
+            getPipelineMock('readYaml').call(file: '/w/thecars/snapcraft-sample-service.yaml') >> [
                 name: 'sample-service',
                 architectures: [
                     [
@@ -294,7 +294,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
             def archList = []
             edgeXReleaseSnap.getBinding().setVariable('env', environmentVariables)
             getPipelineMock('isDryRun')() >> false
-            getPipelineMock('readYaml').call(file: '/w/thecars/snapcraft.yaml') >> [
+            getPipelineMock('readYaml').call(file: '/w/thecars/snapcraft-sample-service.yaml') >> [
                 name: 'sample-service',
                 architectures: [
                     [

--- a/vars/edgeXReleaseSnap.groovy
+++ b/vars/edgeXReleaseSnap.groovy
@@ -70,12 +70,12 @@ def getSnapcraftAddress(repo, branch) {
     repo.replaceAll("\\.git", "").replaceAll("https://github.com/", "https://raw.githubusercontent.com/") + "/${branch}/snap/snapcraft.yaml"
 }
 
-def getSnapMetadata(repo, branch) {
+def getSnapMetadata(repo, branch, name) {
     // return snap meta data for repo
     println "[edgeXReleaseSnap]: getting snap metadata for repo: ${repo} branch: ${branch}"
     def snapCraftAddress = getSnapcraftAddress(repo, branch)
-    sh "curl --fail -o ${env.WORKSPACE}/snapcraft.yaml -O ${snapCraftAddress}"
-    readYaml(file: "${env.WORKSPACE}/snapcraft.yaml")
+    sh "curl --fail -o ${env.WORKSPACE}/snapcraft-${name}.yaml -O ${snapCraftAddress}"
+    readYaml(file: "${env.WORKSPACE}/snapcraft-${name}.yaml")
 }
 
 def getSnapInfo(snapName) {
@@ -109,7 +109,7 @@ def releaseSnap(releaseInfo) {
     try {
         println "[edgeXReleaseSnap]: releasing snaps for: ${releaseInfo.name}"
         // get snap metadata from snapcraft.yaml located in the repo
-        def snapMetadata = getSnapMetadata(releaseInfo.repo, releaseInfo.releaseStream)
+        def snapMetadata = getSnapMetadata(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name)
         // get snap info from snapcraft.io store
         def snapInfo = getSnapInfo(snapMetadata.name)
         snapMetadata.architectures.each { architecture ->


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

We discovered a bug during functional testing, due to how the snapcraft meta data file was being downloaded we noticed that data was being clobbered between parallel runs. To mitigate we will make the downloaded filename for snapcraft explicit by including the release name. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X]  Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/cd-management/issues/3

## Sandbox Testing
NA 

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Updated all impacted unit tests and verified all unit tests are working after the change was made.
