### PR TITLE
Update to use x86 snapcraft image for all snap releases

### DIFF
--- a/src/test/groovy/edgeXReleaseSnapSpec.groovy
+++ b/src/test/groovy/edgeXReleaseSnapSpec.groovy
@@ -272,7 +272,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
             4 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                     archList << _arguments[0][0][0]
                 }
-            assert archList == ['ARCH=arm64', 'ARCH=arm64', 'ARCH=amd64', 'ARCH=amd64']
+            assert archList == ['ARCH=amd64', 'ARCH=amd64', 'ARCH=amd64', 'ARCH=amd64']
             // TODO: figure out why the assertion below didn't work
             // 2 * getPipelineMock('withEnv').call(_) >> { _arguments ->
             //         def envArgs = [
@@ -328,7 +328,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
             4 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                     archList << _arguments[0][0][0]
                 }
-            assert archList == ['ARCH=arm64', 'ARCH=arm64', 'ARCH=amd64', 'ARCH=amd64']
+            assert archList == ['ARCH=amd64', 'ARCH=amd64', 'ARCH=amd64', 'ARCH=amd64']
     }
 
     def "Test edgeXReleaseSnap [Should] echo repo is not snap enabled [When] release info yaml snap is false" () {

--- a/vars/edgeXReleaseSnap.groovy
+++ b/vars/edgeXReleaseSnap.groovy
@@ -126,7 +126,9 @@ def releaseSnap(releaseInfo) {
                         def trackName = snapChannel.trackName ?: 'latest/edge'
                         snapRevision = getSnapRevision(snapInfo, architecture.'build-on', trackName)
                     }
-                    withEnv(["ARCH=${architecture.'build-on'}"]) {
+                    // to facilitate releases we leverage x86 based docker image to release snaps
+                    // revision number is unique and distinguishes between snap architectures
+                    withEnv(['ARCH=amd64']) {
                         def message = """[edgeXReleaseSnap]:\
                             edgeXSnap(jobType: 'release',\
                                 snapChannel: ${snapChannel.channel},\


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

To facilitate release snaps we are leveraging the amd64-based edgex-snap-builder Docker image

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/cd-management/issues/3

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

```
# gradle clean test --tests EdgeXReleaseSnapSpec
> Task :test
Results: SUCCESS (13 tests, 13 successes, 0 failures, 0 skipped)
BUILD SUCCESSFUL in 1m 19s
5 actionable tasks: 5 executed

# gradle clean test
> Task :test
Results: SUCCESS (142 tests, 139 successes, 0 failures, 3 skipped)
BUILD SUCCESSFUL in 2m 40s
5 actionable tasks: 5 executed
```
