### PR TITLE
Add edgeXSemver bump command to command sequence

### DIFF
--- a/vars/edgeXReleaseGitTag.groovy
+++ b/vars/edgeXReleaseGitTag.groovy
@@ -24,6 +24,7 @@ version: '1.1.2'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/sample-service.git'
 gitTag: true
+semverBumpLevel: 'patch'  # optional and defaults to 'pre'
 
 edgeXReleaseGitTag(releaseYaml)
 
@@ -107,10 +108,11 @@ def signGitTag(version, name) {
     }
 }
 
-def pushGitTag(name, version) {
-    // call edgeXSemver push to push git tags
+def bumpAndPushGitTag(name, version, bumpLevel) {
+    // call edgeXSemver bump to bump semver branch to next bumpLevel and push to push git tag
     println "[edgeXReleaseGitTag]: pushing git tag for ${name}: ${version} - DRY_RUN: ${env.DRY_RUN}"
     def commands = [
+        "bump ${bumpLevel}",
         "push"
     ]
     if(edgex.isDryRun()) {
@@ -130,7 +132,8 @@ def releaseGitTag(releaseInfo, credentials) {
     try {
         cloneRepo(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name, credentials)
         setAndSignGitTag(releaseInfo.name, releaseInfo.version)
-        pushGitTag(releaseInfo.name, releaseInfo.version)
+        def semverBumpLevel = releaseInfo.semverBumpLevel ?: 'pre'
+        bumpAndPushGitTag(releaseInfo.name, releaseInfo.version, semverBumpLevel)
     }
     catch(Exception ex) {
         error("[edgeXReleaseGitTag]: ERROR occurred releasing git tag: ${ex}")


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

This adds an edgeXSemver bump command to the git tag release command sequence in order to bump the semver branch on the target repo to the next version level. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/edgex-global-pipelines/issues/168

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Unit tests have been updated and new ones have been added to test the new logic:
```
# gradle clean test --tests EdgeXReleaseGitTagSpec
> Task :test
Results: SUCCESS (16 tests, 16 successes, 0 failures, 0 skipped)

BUILD SUCCESSFUL in 22s
5 actionable tasks: 5 executed

# gradle clean test
> Task :test
Results: SUCCESS (143 tests, 140 successes, 0 failures, 3 skipped)

BUILD SUCCESSFUL in 2m 39s
5 actionable tasks: 5 executed
```