### PR TITLE
Set semverBumpLevel prefix default to be dev

### DIFF
--- a/src/test/groovy/edgeXReleaseGitTagSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagSpec.groovy
@@ -234,6 +234,19 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
             noExceptionThrown()
     }
 
+    def "Test edgeXReleaseGitTag [Should] call edgeXSemver bump with default [When] called" () {
+        setup:
+            getPipelineMock('isDryRun')() >> false
+            explicitlyMockPipelineStep('sshagent')
+            explicitlyMockPipelineStep('edgeXSemver')
+            explicitlyMockPipelineStep('edgeXInfraLFToolsSign')
+            explicitlyMockPipelineStep('dir')
+        when:
+            edgeXReleaseGitTag(validReleaseInfo)
+        then:
+            1 * getPipelineMock('edgeXSemver').call('bump -pre=dev pre')
+    }
+
     def "Test edgeXReleaseGitTag [Should] call edgeXSemver bump [When] called with semverBumpLevel" () {
         setup:
             getPipelineMock('isDryRun')() >> false

--- a/vars/edgeXReleaseGitTag.groovy
+++ b/vars/edgeXReleaseGitTag.groovy
@@ -24,7 +24,7 @@ version: '1.1.2'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/sample-service.git'
 gitTag: true
-semverBumpLevel: 'patch'  # optional and defaults to 'pre'
+semverBumpLevel: 'patch'  # optional and defaults to '-pre=dev pre'
 
 edgeXReleaseGitTag(releaseYaml)
 
@@ -132,7 +132,7 @@ def releaseGitTag(releaseInfo, credentials) {
     try {
         cloneRepo(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name, credentials)
         setAndSignGitTag(releaseInfo.name, releaseInfo.version)
-        def semverBumpLevel = releaseInfo.semverBumpLevel ?: 'pre'
+        def semverBumpLevel = releaseInfo.semverBumpLevel ?: '-pre=dev pre'
         bumpAndPushGitTag(releaseInfo.name, releaseInfo.version, semverBumpLevel)
     }
     catch(Exception ex) {


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

The default prefix for the pre axis in git-semver is 'pre'. Thus updating the semverBumpLevel default value to use 'dev' as the pre axis prefix.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X]  Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
NA

## Sandbox Testing
NA

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Added a new test to assert the default value of semverBumpLevel and confirmed all other tests were successful:
```
# gradle clean test --tests EdgeXReleaseGitTagSpec
> Task :test
Results: SUCCESS (17 tests, 17 successes, 0 failures, 0 skipped)

BUILD SUCCESSFUL in 21s
5 actionable tasks: 5 executed

# gradle clean test
> Task :test
Results: SUCCESS (144 tests, 141 successes, 0 failures, 3 skipped)

BUILD SUCCESSFUL in 2m 35s
5 actionable tasks: 5 executed
```