### PR TITLE
Set SEMVER_BRANCH to be releaseStream

### DIFF
--- a/src/test/groovy/edgeXReleaseGitTagSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagSpec.groovy
@@ -205,6 +205,7 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
 
     def "Test releaseGitTag [Should] catch and and raise error [When] exception occurs" () {
         setup:
+            explicitlyMockPipelineStep('withEnv')
             explicitlyMockPipelineStep('error')
             // TODO: figure out how to properly stub cloneRepo to set side-effect Exception
             // explicitlyMockPipelineVariable('cloneRepo')
@@ -221,8 +222,26 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
             1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: ERROR occurred releasing git tag: java.lang.Exception: SSH Exception')
     }
 
+    def "Test releaseGitTag [Should] set SEMVER_BRANCH env var [When] called" () {
+        setup:
+        setup:
+            explicitlyMockPipelineStep('withEnv')
+            getPipelineMock('isDryRun')() >> false
+            explicitlyMockPipelineStep('sshagent')
+            explicitlyMockPipelineStep('edgeXSemver')
+            explicitlyMockPipelineStep('edgeXInfraLFToolsSign')
+            explicitlyMockPipelineStep('dir')
+        when:
+            edgeXReleaseGitTag.releaseGitTag(validReleaseInfo, 'MyCredentials')
+        then:
+            1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
+                    assert _arguments[0][0][0] == 'SEMVER_BRANCH=master'
+                }
+    }
+
     def "Test edgeXReleaseGitTag [Should] not throw error [When] called with valid release info and DRY_RUN is false" () {
         setup:
+            explicitlyMockPipelineStep('withEnv')
             getPipelineMock('isDryRun')() >> false
             explicitlyMockPipelineStep('sshagent')
             explicitlyMockPipelineStep('edgeXSemver')
@@ -236,6 +255,7 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
 
     def "Test edgeXReleaseGitTag [Should] call edgeXSemver bump with default [When] called" () {
         setup:
+            explicitlyMockPipelineStep('withEnv')
             getPipelineMock('isDryRun')() >> false
             explicitlyMockPipelineStep('sshagent')
             explicitlyMockPipelineStep('edgeXSemver')
@@ -249,6 +269,7 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
 
     def "Test edgeXReleaseGitTag [Should] call edgeXSemver bump [When] called with semverBumpLevel" () {
         setup:
+            explicitlyMockPipelineStep('withEnv')
             getPipelineMock('isDryRun')() >> false
             explicitlyMockPipelineStep('sshagent')
             explicitlyMockPipelineStep('edgeXSemver')

--- a/vars/edgeXReleaseGitTag.groovy
+++ b/vars/edgeXReleaseGitTag.groovy
@@ -131,9 +131,11 @@ def releaseGitTag(releaseInfo, credentials) {
     // exception handled function that clones, sets and signs git tag version
     try {
         cloneRepo(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name, credentials)
-        setAndSignGitTag(releaseInfo.name, releaseInfo.version)
-        def semverBumpLevel = releaseInfo.semverBumpLevel ?: '-pre=dev pre'
-        bumpAndPushGitTag(releaseInfo.name, releaseInfo.version, semverBumpLevel)
+        withEnv(["SEMVER_BRANCH=${releaseInfo.releaseStream}"]) {
+            setAndSignGitTag(releaseInfo.name, releaseInfo.version)
+            def semverBumpLevel = releaseInfo.semverBumpLevel ?: '-pre=dev pre'
+            bumpAndPushGitTag(releaseInfo.name, releaseInfo.version, semverBumpLevel)
+        }
     }
     catch(Exception ex) {
         error("[edgeXReleaseGitTag]: ERROR occurred releasing git tag: ${ex}")


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

This update will explicitly set the `SEMVER_BRANCH` environment variable to be the releaseStream, this is to ensure that the semver branch on the target repo is updated (i.e. bumped) correctly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/edgex-global-pipelines/issues/175

## Sandbox Testing
I did verify that withEnv spans docker image execution:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/quick-test/configure

## Are there any specific instructions or things that should be known prior to reviewing?
After this is merged and the experimental tag is updated, I will functionally test this change using the following PR:
https://github.com/edgexfoundry/cd-management/pull/8

## Other information
Added new unit tests and verified all existing unit tests passed:
```
# gradle clean test --tests EdgeXReleaseGitTagSpec
> Task :test
Results: SUCCESS (18 tests, 18 successes, 0 failures, 0 skipped)

BUILD SUCCESSFUL in 21s
5 actionable tasks: 5 executed

# gradle clean test
> Task :test
Results: SUCCESS (144 tests, 141 successes, 0 failures, 3 skipped)

BUILD SUCCESSFUL in 2m 37s
5 actionable tasks: 5 executed
```

