### PR TITLE
Update Snyk version to 1.317.0

### DIFF
--- a/src/test/groovy/edgeXSnykSpec.groovy
+++ b/src/test/groovy/edgeXSnykSpec.groovy
@@ -16,7 +16,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
                 'WORKSPACE': 'MyWorkspace'
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk()
         then:
@@ -30,7 +30,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
                 'SNYK_ORG': 'MySnykOrg'
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk()
         then:
@@ -43,7 +43,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
                 'WORKSPACE': 'MyWorkspace'
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk('MyDockerImage', 'MyDockerFile')
         then:
@@ -56,7 +56,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
                 'WORKSPACE': 'MyWorkspace'
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk('MyDockerImage', 'MyDockerFile')
         then:

--- a/vars/edgeXSnyk.groovy
+++ b/vars/edgeXSnyk.groovy
@@ -15,7 +15,7 @@
 //
 
 def call(dockerImage = null, dockerFile = null) {
-    def snykImage = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.217.3'
+    def snykImage = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0'
     def org = env.SNYK_ORG ?: 'edgex-jenkins'
 
     // Run snyk monitor by default


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Update Snyk to the latest version of the CLI

## Issue Number:
https://github.com/edgexfoundry/ci-build-images/issues/133
## Sandbox Testing
Test Links : N/A


## Are there any specific instructions or things that should be known prior to reviewing?
Snyk base image has already been updated to 1.317.0 and the Go version is 1.13.  This addresses the issue discovered where the Snyk portal doesn't reflect the correct version of Go.

## Other information
Signed-off-by: James Gregg <james.r.gregg@intel.com>