### PR TITLE
Global function for SwaggerHub publishing.

### DIFF
--- a/resources/edgex-publish-swagger.sh
+++ b/resources/edgex-publish-swagger.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e -o pipefail
+echo "--> edgex-go-publish-swagger.sh"
+# if no ARCH is set or ARCH is not arm
+if [ -z "$ARCH" ] || [ "$ARCH" != "arm64" ] ; then
+    # NOTE: APIKEY needs to be a pointer to a file with the key. This will need to be set locally from your environment or from Jenkins
+    APIKEY_VALUE=`cat $APIKEY`
+    # Upload both API versions,v1 and v2, to SwaggerHub
+    API_FOLDERS="v1 v2"
+    SWAGGER_DRY_RUN=${SWAGGER_DRY_RUN:-false}
+    SCRIPTS_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+    . $SCRIPTS_ROOT/toSwaggerHub.sh
+    OASVERSION='3.0.0'
+    ISPRIVATE=false
+    OWNER=${1:-EdgeXFoundry1}
+    for API_FOLDER in ${API_FOLDERS}; do
+        echo "=== Publish ${API_FOLDER} API ==="
+        publishToSwagger "${APIKEY_VALUE}" "${API_FOLDER}" "${OASVERSION}" "${ISPRIVATE}" "${OWNER}" "${SWAGGER_DRY_RUN}"
+    done
+else
+    echo "$ARCH not supported...skipping."
+fi

--- a/resources/toSwaggerHub.sh
+++ b/resources/toSwaggerHub.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+echo "--> toSwaggerHub.sh"
+
+publishToSwagger() {
+    apiKey=$1
+    apiFolder=$2
+    oasVersion=$3
+    isPrivate=$4
+    owner=$5
+    dryRun=${6:-false}
+
+    apiPath="$WORKSPACE/api/openapi/"${apiFolder}
+
+    echo "[toSwaggerHub] Publishing the API Docs [${apiFolder}] to Swagger"
+
+    if [ -d "$apiPath" ]; then
+        for file in "${apiPath}"/*.yaml; do
+            apiName=$(basename "${file}" | cut -d "." -f 1)
+            apiContent=$(cat "${apiPath}/${apiName}".yaml)
+
+            echo "[toSwaggerHub] Publishing API Name [$apiName]"
+
+            if [ "$dryRun" == "false" ]; then
+                curl -X POST "https://api.swaggerhub.com/apis/${owner}/${apiName}?oas=${oasVersion}&isPrivate=${isPrivate}&force=true" \
+                    -H "accept:application/json" \
+                    -H "Authorization:${apiKey}" \
+                    -H "Content-Type:application/yaml" \
+                    -d "${apiContent}"
+                echo $'\n'
+            else
+                echo "[toSwaggerHub] Dry Run enabled...Simulating upload"
+                echo "curl -X POST https://api.swaggerhub.com/apis/${owner}/${apiName}?oas=${oasVersion}&isPrivate=${isPrivate}&force=true"
+            fi
+
+        done
+    else
+        echo "Could not find API Folder [${apiPath}]. Please make sure the API version exists..."
+        exit 1
+    fi
+}

--- a/src/test/groovy/edgeXSwaggerPublishSpec.groovy
+++ b/src/test/groovy/edgeXSwaggerPublishSpec.groovy
@@ -1,0 +1,59 @@
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+import spock.lang.Ignore
+
+public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
+
+    def edgeXSwaggerPublish = null
+
+    def setup() {
+        edgeXSwaggerPublish = loadPipelineScriptForTest('vars/edgeXSwaggerPublish.groovy')
+        explicitlyMockPipelineVariable('out')
+        explicitlyMockPipelineVariable('error')
+        explicitlyMockPipelineVariable('writeFile')
+        edgeXSwaggerPublish.getBinding().setVariable('edgex', {})
+        explicitlyMockPipelineStep('isDryRun')
+        explicitlyMockPipelineStep('withEnv')
+    }
+
+    def "Test edgeXSwaggerPublish [Should] call shell script with expected arguments [When] no owner is provided" () {
+        when:
+            edgeXSwaggerPublish()
+        then:
+            1 * getPipelineMock('sh').call('./edgex-publish-swagger.sh EdgeXFoundry1')
+    }
+
+    def "Test edgeXSwaggerPublish [Should] call shell script with expected arguments [When] owner is provided" () {
+        when:
+            edgeXSwaggerPublish('Moby')
+        then:
+            1 * getPipelineMock('sh').call('./edgex-publish-swagger.sh Moby')
+    }
+    
+    def "Test retreieveResourceScripts [Should] retrieve files from global pipeline library [When] files are provided" () {
+        when:
+            edgeXSwaggerPublish.retreieveResourceScripts(["toSwaggerHub.sh", "edgex-publish-swagger.sh"])
+        then:
+            1 * getPipelineMock('libraryResource').call('toSwaggerHub.sh')
+            1 * getPipelineMock('libraryResource').call('edgex-publish-swagger.sh')
+            1 * getPipelineMock('writeFile.call').call(['file':'./toSwaggerHub.sh', 'text':null])
+            1 * getPipelineMock('writeFile.call').call(['file':'./edgex-publish-swagger.sh', 'text':null])
+    }
+
+    def "Test edgeXSwaggerPublish [Should] should execute shell script correctly [When] DRY_RUN is true" () {
+        setup:
+            getPipelineMock('isDryRun')() >> true
+            explicitlyMockPipelineStep('withEnv')
+            def environmentVariables = ['DRY_RUN': 'true']
+            edgeXSwaggerPublish.getBinding().setVariable('env', environmentVariables)
+        when:
+            edgeXSwaggerPublish()
+        then:
+            1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
+                def envArgs = [
+                    'SWAGGER_DRY_RUN=true'
+                ]
+                assert envArgs == _arguments[0][0]
+            }
+    }
+
+}

--- a/vars/edgeXSwaggerPublish.groovy
+++ b/vars/edgeXSwaggerPublish.groovy
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+
+edgeXSwaggerPublish(releaseYaml)
+/*
+   Usage: edgeXSwaggerPublish() # defaults to EdgeXFoundry1
+   Usage: edgeXSwaggerPublish('custom-owner')
+*/
+
+def call(owner = 'EdgeXFoundry1') {
+    try{
+        println("[edgeXSwaggerPublish]: Retrieving edgex-global-pipeline resource shell scripts. - DRY_RUN: ${env.DRY_RUN}")
+        retreieveResourceScripts(["toSwaggerHub.sh", "edgex-publish-swagger.sh"])
+        def dryRun = edgex.isDryRun()
+        withEnv(["SWAGGER_DRY_RUN=${dryRun}"]) {
+            sh "./edgex-publish-swagger.sh ${owner}"
+        }
+    }
+    catch(Exception ex) {
+        error("[edgeXSwaggerPublish]: ERROR occurred publishing to SwaggerHub: ${ex}")
+    }
+}
+
+def retreieveResourceScripts(files){ 
+    files.each{ file ->
+        print("[edgeXSwaggerPublish] Retrieving: ${file}")
+        def textDestination = libraryResource(file)
+        writeFile(file: "./${file}", text: textDestination)
+        sh "chmod +x ./${file}"
+    }
+}


### PR DESCRIPTION
Global function for SwaggerHub publishing. A wrapper of existing shell scripts to deploy to swagger hub.

*Adds ability to optionally specify a different "owner" (Defaults to EdgeXFoundry1)

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#188 
## Sandbox Testing
Test Links :

[Sand Box Link Fails due to lack of SwaggerHub Credentials on Sandbox](https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional%20Testing/job/edgeXSwaggerPublish/2/console)

Using my Personal SwaggerHub Token it lets me push this to my own account using a forked version of sample-service
![image](https://user-images.githubusercontent.com/61600932/85900219-4c47ed80-b7b4-11ea-9711-be735ed20a8a.png)

## Are there any new imports or modules? If so, what are they used for and why?
No
## Are there any specific instructions or things that should be known prior to reviewing?
No
## Other information
edgex-go/Jenkinsfile is the only place swaggerhub publish functionality exists. To take advantage of this global function this is what needs to get changed next.

Note: The 2 added *.sh files are copies from ci-management repo and their usage from that repo should be deprecated in the future.
