### PR TITLE
add ability to override snap builder image version tag

### DIFF
--- a/vars/edgeXSnap.groovy
+++ b/vars/edgeXSnap.groovy
@@ -31,11 +31,12 @@ snapStoreLoginSettings, the name of the Jenkins settings file with login details
 
 def call(config = [:]) {
     def _arch = env.ARCH ?: 'amd64'
-    def _snapBuilderImage = config.snapBuilderImage ?: "${DOCKER_REGISTRY}:10003/edgex-devops/edgex-snap-builder:latest"
+    def _snapBuilderVersion = config.snapBuilderVersion ?: 'latest'
+    def _snapBuilderImage = config.snapBuilderImage ?: "${DOCKER_REGISTRY}:10003/edgex-devops/edgex-snap-builder:${_snapBuilderVersion}"
 
     // TODO: find a better way to do this
     if(_arch == 'arm64') {
-        _snapBuilderImage = "${DOCKER_REGISTRY}:10003/edgex-devops/edgex-snap-builder-${_arch}:latest"
+        _snapBuilderImage = "${DOCKER_REGISTRY}:10003/edgex-devops/edgex-snap-builder-${_arch}:${_snapBuilderVersion}"
     }
 
     def _snapBase     = config.snapBase ?: env.WORKSPACE


### PR DESCRIPTION
Currently, there is no real easy way to test alternate versions of the snap builder image. The PR gives us that ability.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
