### PR TITLE
feat: add geneva as a valid release stream

### DIFF
--- a/src/test/groovy/edgexSpec.groovy
+++ b/src/test/groovy/edgexSpec.groovy
@@ -28,6 +28,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
             edgeX.isReleaseStream('delhi') == true
             edgeX.isReleaseStream('edinburgh') == true
             edgeX.isReleaseStream('fuji') == true
+            edgeX.isReleaseStream('geneva') == true
             edgeX.isReleaseStream('xyzmaster') == false
             edgeX.isReleaseStream('masterxyz') == false
             edgeX.isReleaseStream('xyzmasterxyz') == false
@@ -43,6 +44,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
             edgeX.isReleaseStream('delhi') == false
             edgeX.isReleaseStream('edinburgh') == false
             edgeX.isReleaseStream('fuji') == false
+            edgeX.isReleaseStream('geneva') == false
             edgeX.isReleaseStream('xyzmaster') == false
             edgeX.isReleaseStream('masterxyz') == false
             edgeX.isReleaseStream('xyzmasterxyz') == false

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -16,7 +16,7 @@
 
 def isReleaseStream(branchName = env.GIT_BRANCH) {
     // what defines a main release branch
-    def releaseStreams = [/^master$/, /^california$/, /^delhi$/, /^edinburgh$/, /^fuji$/]
+    def releaseStreams = [/^master$/, /^california$/, /^delhi$/, /^edinburgh$/, /^fuji$/, /^geneva$/]
     env.SILO == 'production' && (branchName && (releaseStreams.collect { branchName =~ it ? true : false }).contains(true))
 }
 


### PR DESCRIPTION
Certain repos e.g. [device-sdk-c](https://github.com/edgexfoundry/device-sdk-c/tree/geneva) are creating `geneva` branches and git-semver and other stages are not running due to geneva not being considered a valid release stream. This PR fixes that issue.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
