### PR TITLE
Change swagger path since the path has updated from api/openapi to openapi  on edgex-go

### DIFF
--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -109,7 +109,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     SNAP_CHANNEL: 'latest/edge',
                     BUILD_SNAP: false,
                     PUBLISH_SWAGGER_DOCS: false,
-                    SWAGGER_API_FOLDERS: 'api/openapi/v1'
+                    SWAGGER_API_FOLDERS: 'openapi/v1'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -106,7 +106,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     SEMVER_BUMP_LEVEL: 'pre',
                     GOPROXY: 'https://nexus3.edgexfoundry.org/repository/go-proxy/',
                     PUBLISH_SWAGGER_DOCS: false,
-                    SWAGGER_API_FOLDERS: 'api/openapi/v1 api/openapi/v2'
+                    SWAGGER_API_FOLDERS: 'openapi/v1 openapi/v2'
                     /*SNAP_CHANNEL: 'latest/edge',
                     BUILD_SNAP: false,
                     */

--- a/src/test/groovy/edgeXSwaggerPublishSpec.groovy
+++ b/src/test/groovy/edgeXSwaggerPublishSpec.groovy
@@ -41,14 +41,14 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
     def "Test edgeXSwaggerPublish [Should] call shell script with expected arguments [When] owner is provided" () {
         when:
             getPipelineMock('isDryRun')() >> false
-            edgeXSwaggerPublish(owner: 'Moby', apiFolders:'api/openapi/v1 api/openapi/v2')
+            edgeXSwaggerPublish(owner: 'Moby', apiFolders:'openapi/v1 openapi/v2')
         then:
             1 * getPipelineMock("libraryResource").call('edgex-publish-swagger.sh')
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                 def envArgs = [
                     'SWAGGER_DRY_RUN=false',
                     'OWNER=Moby',
-                    'API_FOLDERS=api/openapi/v1 api/openapi/v2'
+                    'API_FOLDERS=openapi/v1 openapi/v2'
                 ]
                 assert envArgs == _arguments[0][0]
             }
@@ -61,13 +61,13 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
             def environmentVariables = ['DRY_RUN': 'true']
             edgeXSwaggerPublish.getBinding().setVariable('env', environmentVariables)
         when:
-            edgeXSwaggerPublish(apiFolders: 'api/openapi/v1 api/openapi/v2 custom_api')
+            edgeXSwaggerPublish(apiFolders: 'openapi/v1 openapi/v2 custom_api')
         then:
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                 def envArgs = [
                     'SWAGGER_DRY_RUN=true',
                     'OWNER=EdgeXFoundry1',
-                    'API_FOLDERS=api/openapi/v1 api/openapi/v2 custom_api'
+                    'API_FOLDERS=openapi/v1 openapi/v2 custom_api'
                 ]
                 assert envArgs == _arguments[0][0]
             }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -442,7 +442,7 @@ def toEnvironment(config) {
     def _snapChannel         = config.snapChannel ?: 'latest/edge'
     def _buildSnap           = edgex.defaultFalse(config.buildSnap)
     def _publishSwaggerDocs  = edgex.defaultFalse(config.publishSwaggerDocs)
-    def _swaggerApiFolders   = config.swaggerApiFolders ?: ['api/openapi/v1']
+    def _swaggerApiFolders   = config.swaggerApiFolders ?: ['openapi/v1']
 
     def _buildExperimentalDockerImage  = edgex.defaultFalse(config.buildExperimentalDockerImage)
     def _buildStableDockerImage        = false

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -423,7 +423,7 @@ def toEnvironment(config) {
     def _semverBump            = config.semverBump ?: 'pre'
     def _goProxy               = config.goProxy ?: 'https://nexus3.edgexfoundry.org/repository/go-proxy/'
     def _publishSwaggerDocs    = edgex.defaultFalse(config.publishSwaggerDocs)
-    def _swaggerApiFolders     = config.swaggerApiFolders ?: ['api/openapi/v1', 'api/openapi/v2']
+    def _swaggerApiFolders     = config.swaggerApiFolders ?: ['openapi/v1', 'openapi/v2']
 
     // commenting these out for now as edgex-go has a nightly snap build
     // maybe we can integrate in the future if we can get the build time

--- a/vars/edgeXSwaggerPublish.groovy
+++ b/vars/edgeXSwaggerPublish.groovy
@@ -18,10 +18,10 @@
 NOTE: APIKEY needs to be a pointer to a file with the key. This will need to be set locally from your environment or from Jenkins
 edgeXSwaggerPublish(optional owner, apiFolder)
 /*
-   Usage: edgeXSwaggerPublish(apiFolders: 'api/openapi/v1 api/openapi/v2') Defaults to owner:EdgeXFoundry1
-   Usage: edgeXSwaggerPublish(apiFolders: 'api/openapi/v1') Defaults to owner:EdgeXFoundry1
-   Usage: edgeXSwaggerPublish(owner: 'customOwner', apiFolders:'api/openapi/v1')
-   Usage: edgeXSwaggerPublish(owner: 'customOwner', apiFolders:'api/openapi/v1 api/openapi/v2')
+   Usage: edgeXSwaggerPublish(apiFolders: 'openapi/v1 openapi/v2') Defaults to owner:EdgeXFoundry1
+   Usage: edgeXSwaggerPublish(apiFolders: 'openapi/v1') Defaults to owner:EdgeXFoundry1
+   Usage: edgeXSwaggerPublish(owner: 'customOwner', apiFolders:'openapi/v1')
+   Usage: edgeXSwaggerPublish(owner: 'customOwner', apiFolders:'openapi/v1 openapi/v2')
 */
 
 def call(Map config = [:]) {


### PR DESCRIPTION

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number: 
Fix #221 
## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Related PR [edgex-go #2644](https://github.com/edgexfoundry/edgex-go/pull/2644)