### PR TITLE
Remove unnecessary exception wrapping when testing error

### DIFF
--- a/src/test/groovy/edgeXBuildCAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildCAppSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
 
     def edgeXBuildCApp = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
 
         edgeXBuildCApp = loadPipelineScriptForTest('vars/edgeXBuildCApp.groovy')
@@ -63,13 +57,9 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] config does not include a project parameter" () {
         setup:
         when:
-            try {
-                edgeXBuildCApp.validate([:])
-            }
-            catch(TestException exception) {
-            }
+            edgeXBuildCApp.validate([:])
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('[edgeXBuildCApp] The parameter "project" is required. This is typically the project name.')
     }
 
     def "Test toEnvironment [Should] return expected map of default values [When] sandbox environment" () {

--- a/src/test/groovy/edgeXBuildDockerSpec.groovy
+++ b/src/test/groovy/edgeXBuildDockerSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
 
     def edgeXBuildDocker = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXBuildDocker = loadPipelineScriptForTest('vars/edgeXBuildDocker.groovy')
 
@@ -20,13 +14,9 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] config has no project" () {
         setup:
         when:
-            try {
-                edgeXBuildDocker.validate([:])
-            }
-            catch(TestException exception) {
-            }
+            edgeXBuildDocker.validate([:])
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('[edgeXBuildDocker] The parameter "project" is required. This is typically the project name')
     }
 
     def "Test toEnvironment [Should] return expected map [When] called" () {

--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
 
     def edgeXBuildGoApp = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXBuildGoApp = loadPipelineScriptForTest('vars/edgeXBuildGoApp.groovy')
 
@@ -58,13 +52,9 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] config does not include a project parameter" () {
         setup:
         when:
-            try {
-                edgeXBuildGoApp.validate([:])
-            }
-            catch(TestException exception) {
-            }
+            edgeXBuildGoApp.validate([:])
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('[edgeXBuildGoApp] The parameter "project" is required. This is typically the project name.')
     }
 
     def "Test toEnvironment [Should] return expected map of default values [When] sandbox environment" () {

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
 
     def edgeXBuildGoParallel = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXBuildGoParallel = loadPipelineScriptForTest('vars/edgeXBuildGoParallel.groovy')
 
@@ -64,13 +58,9 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] config does not include a project parameter" () {
         setup:
         when:
-            try {
-                edgeXBuildGoParallel.validate([:])
-            }
-            catch(TestException exception) {
-            }
+            edgeXBuildGoParallel.validate([:])
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('[edgeXBuildGoParallel] The parameter "project" is required. This is typically the project name.')
     }
 
     def "Test toEnvironment [Should] return expected map of default values [When] sandbox environment" () {

--- a/src/test/groovy/edgeXClairSpec.groovy
+++ b/src/test/groovy/edgeXClairSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXClairSpec extends JenkinsPipelineSpecification {
 
     def edgeXClair = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) {
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXClair = loadPipelineScriptForTest('vars/edgeXClair.groovy')
         explicitlyMockPipelineVariable('out')
@@ -18,15 +12,11 @@ public class EdgeXClairSpec extends JenkinsPipelineSpecification {
 
     def "Test edgeXClair [Should] raise error [When] no image is provided" () {
         setup:
-            // NOTE - docker and shstill needs to be stubbed because error below is caught but execution will continue
+            // NOTE - docker and sh still needs to be stubbed because error is mocked and apparently doesn't halt execution of method
             getPipelineMock('docker.image')(_) >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(_) >> ''
         when:
-            try {
-                edgeXClair('')
-            }
-            catch(TestException exception) {
-            }
+            edgeXClair('')
         then:
             1 * getPipelineMock('error').call("edgeXClair scanner requires docker image to scan: [edgeXClair('dockerImage:tag')]")
     }

--- a/src/test/groovy/edgeXDockerLoginSpec.groovy
+++ b/src/test/groovy/edgeXDockerLoginSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXDockerLoginSpec extends JenkinsPipelineSpecification {
 
     def edgeXDockerLogin = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
 
         edgeXDockerLogin = loadPipelineScriptForTest('vars/edgeXDockerLogin.groovy')
@@ -19,62 +13,46 @@ public class EdgeXDockerLoginSpec extends JenkinsPipelineSpecification {
     def "Test call [Should] raise error [When] config has no settingsFile" () {
         setup:
         when:
-            try {
-                edgeXDockerLogin()
-            }
-            catch(TestException exception) {
-            }
+            edgeXDockerLogin()
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('Project Settings File id (settingsFile) is required for the docker login script.')
     }
 
     def "Test call [Should] raise error [When] config has dockerRegistry but no dockerRegistryPorts" () {
         setup:
         when:
-            try {
-                def config = [
-                    'settingsFile': 'settingsFile',
-                    'dockerRegistry': 'dockerRegistry'
-                ]
-                edgeXDockerLogin(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                'settingsFile': 'settingsFile',
+                'dockerRegistry': 'dockerRegistry'
+            ]
+            edgeXDockerLogin(config)
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('Docker registry ports (dockerRegistryPorts) are required when docker registry is set (dockerRegistry).')
     }
 
     def "Test call [Should] raise error [When] config has dockerRegistryPorts but no dockerRegistry" () {
         setup:
         when:
-            try {
-                def config = [
-                    'settingsFile': 'settingsFile',
-                    'dockerRegistryPorts': 'dockerRegistryPorts'
-                ]
-                edgeXDockerLogin(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                'settingsFile': 'settingsFile',
+                'dockerRegistryPorts': 'dockerRegistryPorts'
+            ]
+            edgeXDockerLogin(config)
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('Docker registry (dockerRegistry) is required when docker registry ports are set (dockerRegistryPorts).')
     }
 
     def "Test call [Should] call expected [When] called" () {
         setup:
         when:
-            try {
-                def config = [
-                    'settingsFile': 'settingsFile',
-                    'dockerRegistry': 'dockerRegistry',
-                    'dockerRegistryPorts': 'dockerRegistryPorts',
-                    'dockerHubRegistry': 'dockerHubRegistry',
-                    'dockerHubEmail': 'dockerHubEmail'
-                ]
-                edgeXDockerLogin(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                'settingsFile': 'settingsFile',
+                'dockerRegistry': 'dockerRegistry',
+                'dockerRegistryPorts': 'dockerRegistryPorts',
+                'dockerHubRegistry': 'dockerHubRegistry',
+                'dockerHubEmail': 'dockerHubEmail'
+            ]
+            edgeXDockerLogin(config)
         then:
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                 def envArgs = [

--- a/src/test/groovy/edgeXGenericSpec.groovy
+++ b/src/test/groovy/edgeXGenericSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXGenericSpec extends JenkinsPipelineSpecification {
 
     def edgeXGeneric = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXGeneric = loadPipelineScriptForTest('vars/edgeXGeneric.groovy')
 
@@ -21,13 +15,9 @@ public class EdgeXGenericSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] config has no project" () {
         setup:
         when:
-            try {
-                edgeXGeneric.validate([:])
-            }
-            catch(TestException exception) {
-            }
+            edgeXGeneric.validate([:])
         then:
-            1 * getPipelineMock('error').call(_ as String)
+            1 * getPipelineMock('error').call('[edgeXGeneric] The parameter "project" is required. This is typically the project name.')
     }
 
     def "Test toEnvironment [Should] return expected [When] called - DD" () {

--- a/src/test/groovy/edgeXInfraLFToolsSignSpec.groovy
+++ b/src/test/groovy/edgeXInfraLFToolsSignSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXInfraLFToolsSignSpec extends JenkinsPipelineSpecification {
 
     def edgeXInfraLFToolsSign = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) {
-            super( _message );
-        }
-    }
-
     def setup() {
 
         edgeXInfraLFToolsSign = loadPipelineScriptForTest('vars/edgeXInfraLFToolsSign.groovy')
@@ -19,14 +13,10 @@ public class EdgeXInfraLFToolsSignSpec extends JenkinsPipelineSpecification {
 
     def "Test edgeXInfraLFToolsSign [Should] raise error [When] directory is null and command is 'dir'" () {
         setup:
-            // NOTE - docker still needs to be stubbed because error below is caught but execution will continue
+            // NOTE - docker still needs to be stubbed because error is mocked
             getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-lftools:0.23.1-centos7') >> explicitlyMockPipelineVariable()
         when:
-            try {
-                edgeXInfraLFToolsSign([command: 'dir', directory: null])
-            }
-            catch(TestException exception) {
-            }
+            edgeXInfraLFToolsSign([command: 'dir', directory: null])
         then:
             1 * getPipelineMock('error').call('Directory location (directory) is required to sign files in a directory.')
     }
@@ -36,11 +26,7 @@ public class EdgeXInfraLFToolsSignSpec extends JenkinsPipelineSpecification {
             // NOTE - docker still needs to be stubbed because error below is caught but execution will continue
             getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-lftools:0.23.1-centos7') >> explicitlyMockPipelineVariable()
         when:
-            try {
-                edgeXInfraLFToolsSign([command: 'git-tag', version: null])
-            }
-            catch(TestException exception) {
-            }
+            edgeXInfraLFToolsSign([command: 'git-tag', version: null])
         then:
             1 * getPipelineMock('error').call('Version number (version) is required to sign a git teg.')
     }
@@ -48,11 +34,7 @@ public class EdgeXInfraLFToolsSignSpec extends JenkinsPipelineSpecification {
     def "Test edgeXInfraLFToolsSign [Should] raise error [When] command is null" () {
         setup:
         when:
-            try {
-                edgeXInfraLFToolsSign([command: ''])
-            }
-            catch(TestException exception) {
-            }
+            edgeXInfraLFToolsSign([command: ''])
         then:
             1 * getPipelineMock('error').call("Invalid command (command: ) provided for the edgeXInfraLFToolsSign function. (Valid values: dir, git-tag)")
     }
@@ -118,11 +100,7 @@ public class EdgeXInfraLFToolsSignSpec extends JenkinsPipelineSpecification {
                 return 'sigul-configuration-cleanup'
             }
         when:
-            try {
-                edgeXInfraLFToolsSign([command: 'invalid command'])
-            }
-            catch(TestException exception) {
-            }
+            edgeXInfraLFToolsSign([command: 'invalid command'])
         then:
             1 * getPipelineMock('sh').call([script:'sigul-configuration'])
             1 * getPipelineMock('sh').call('mkdir /home/jenkins && mkdir /home/jenkins/sigul')

--- a/src/test/groovy/edgeXNexusPublishSpec.groovy
+++ b/src/test/groovy/edgeXNexusPublishSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXNexusPublishSpec extends JenkinsPipelineSpecification {
 
     def edgeXNexusPublish = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXNexusPublish = loadPipelineScriptForTest('vars/edgeXNexusPublish.groovy')
         explicitlyMockPipelineVariable('out')
@@ -71,14 +65,10 @@ public class EdgeXNexusPublishSpec extends JenkinsPipelineSpecification {
             getPipelineMock('sh')([script: 'uname -m', returnStdout: true]) >> '\n'
             def String[] zipFiles = []
         when:
-            try {
-                def config = [
-                    path: 'MyNexusPath'
-                ]
-                edgeXNexusPublish(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                path: 'MyNexusPath'
+            ]
+            edgeXNexusPublish(config)
         then:
             1 * getPipelineMock('findFiles').call([glob: null]) >> zipFiles
             1 * getPipelineMock('error').call("[edgeXNexusPublish] serverId is required to publish to nexus. Example: 'logs'")
@@ -89,15 +79,11 @@ public class EdgeXNexusPublishSpec extends JenkinsPipelineSpecification {
             getPipelineMock('sh')([script: 'uname -m', returnStdout: true]) >> '\n'
             def String[] zipFiles = []
         when:
-            try {
-                def config = [
-                    path: 'MyNexusPath',
-                    serverId: 'MyServerId'
-                ]
-                edgeXNexusPublish(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                path: 'MyNexusPath',
+                serverId: 'MyServerId'
+            ]
+            edgeXNexusPublish(config)
         then:
             1 * getPipelineMock('findFiles').call([glob: null]) >> zipFiles
             1 * getPipelineMock('error').call("[edgeXNexusPublish] mavenSettings is required to publish to nexus. Example: 'sandbox-settings'")
@@ -108,16 +94,12 @@ public class EdgeXNexusPublishSpec extends JenkinsPipelineSpecification {
             getPipelineMock('sh')([script: 'uname -m', returnStdout: true]) >> '\n'
             def String[] zipFiles = []
         when:
-            try {
-                def config = [
-                    path: 'MyNexusPath',
-                    serverId: 'MyServerId',
-                    mavenSettings: 'MySetting1,MySetting2'
-                ]
-                edgeXNexusPublish(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                path: 'MyNexusPath',
+                serverId: 'MyServerId',
+                mavenSettings: 'MySetting1,MySetting2'
+            ]
+            edgeXNexusPublish(config)
         then:
             1 * getPipelineMock('findFiles').call([glob: null]) >> zipFiles
             1 * getPipelineMock('error').call("[edgeXNexusPublish] nexusRepo is required to publish to nexus. Example: 'logs'")
@@ -128,17 +110,13 @@ public class EdgeXNexusPublishSpec extends JenkinsPipelineSpecification {
             getPipelineMock('sh')([script: 'uname -m', returnStdout: true]) >> '\n'
             def String[] zipFiles = []
         when:
-            try {
-                def config = [
-                    path: 'MyNexusPath',
-                    serverId: 'MyServerId',
-                    mavenSettings: 'MySetting1,MySetting2',
-                    nexusRepo: 'MyNexusRepo'
-                ]
-                edgeXNexusPublish(config)
-            }
-            catch(TestException exception) {
-            }
+            def config = [
+                path: 'MyNexusPath',
+                serverId: 'MyServerId',
+                mavenSettings: 'MySetting1,MySetting2',
+                nexusRepo: 'MyNexusRepo'
+            ]
+            edgeXNexusPublish(config)
         then:
             1 * getPipelineMock('findFiles').call([glob: null]) >> zipFiles
             1 * getPipelineMock('error').call("[edgeXNexusPublish] zipFilePath is required to publish to nexus. Example: '**/*.zip'")

--- a/src/test/groovy/edgeXReleaseDockerImageIntSpec.groovy
+++ b/src/test/groovy/edgeXReleaseDockerImageIntSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXReleaseDockerImageIntSpec extends JenkinsPipelineSpecification
     def edgeXReleaseDockerImage, edgex
     def validReleaseYaml, invalidReleaseYaml
     
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) {
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXReleaseDockerImage = loadPipelineScriptForTest('vars/edgeXReleaseDockerImage.groovy')
 
@@ -71,10 +65,7 @@ public class EdgeXReleaseDockerImageIntSpec extends JenkinsPipelineSpecification
             edgex.getBinding().setVariable('env', environmentVariables)
 
         when:
-
-            try {
-                edgeXReleaseDockerImage.publishDockerImages(validReleaseYaml)
-            } catch(TestException exception) { }
+            edgeXReleaseDockerImage.publishDockerImages(validReleaseYaml)
         then:
             1 * getPipelineMock('echo').call("[edgeXReleaseDockerImage] DRY_RUN: docker login happens here")
 
@@ -114,10 +105,7 @@ public class EdgeXReleaseDockerImageIntSpec extends JenkinsPipelineSpecification
             edgex.getBinding().setVariable('env', environmentVariables)
 
         when:
-
-            try {
-                edgeXReleaseDockerImage.publishDockerImages(validReleaseYaml)
-            } catch(TestException exception) { }
+            edgeXReleaseDockerImage.publishDockerImages(validReleaseYaml)
         then:
             1 * getPipelineMock('echo').call("[edgeXReleaseDockerImage] DRY_RUN: docker login happens here")
 
@@ -162,9 +150,7 @@ public class EdgeXReleaseDockerImageIntSpec extends JenkinsPipelineSpecification
             explicitlyMockPipelineVariable('edgeXDockerLogin')
 
         when:
-            try {
-                edgeXReleaseDockerImage.publishDockerImages(validReleaseYaml)
-            } catch(TestException exception) { }
+            edgeXReleaseDockerImage.publishDockerImages(validReleaseYaml)
         then:
             1 * getPipelineMock('edgeXDockerLogin.call')(settingsFile: 'some-settings')
 
@@ -196,9 +182,7 @@ public class EdgeXReleaseDockerImageIntSpec extends JenkinsPipelineSpecification
             explicitlyMockPipelineVariable('edgeXDockerLogin')
 
         when:
-            try {
-                edgeXReleaseDockerImage.publishDockerImages(invalidReleaseYaml)
-            } catch(TestException exception) { }
+            edgeXReleaseDockerImage.publishDockerImages(invalidReleaseYaml)
         then:
             1 * getPipelineMock('echo').call("[edgeXReleaseDockerImage] The sourceImage [nexus3.edgexfoundry.org:10004/docker-app-functions-sdk-go:master] did not release...")
     }

--- a/src/test/groovy/edgeXReleaseDockerImageSpec.groovy
+++ b/src/test/groovy/edgeXReleaseDockerImageSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXReleaseDockerImageSpec extends JenkinsPipelineSpecification {
     def edgeXReleaseDockerImage
     def validReleaseYaml
     
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) {
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXReleaseDockerImage = loadPipelineScriptForTest('vars/edgeXReleaseDockerImage.groovy')
 
@@ -110,11 +104,7 @@ public class EdgeXReleaseDockerImageSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not contain docker attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseDockerImage.validate(validReleaseYaml.findAll {it.key != 'docker'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseDockerImage.validate(validReleaseYaml.findAll {it.key != 'docker'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseDockerImage] Release yaml does not contain a list \'docker\' images')
     }
@@ -122,11 +112,7 @@ public class EdgeXReleaseDockerImageSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a releaseStream attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseDockerImage.validate(validReleaseYaml.findAll {it.key != 'releaseStream'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseDockerImage.validate(validReleaseYaml.findAll {it.key != 'releaseStream'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseDockerImage] Release yaml does not contain \'releaseStream\' (branch where you are releasing from). Example: master')
     }
@@ -134,11 +120,7 @@ public class EdgeXReleaseDockerImageSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a version attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseDockerImage.validate(validReleaseYaml.findAll {it.key != 'version'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseDockerImage.validate(validReleaseYaml.findAll {it.key != 'version'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseDockerImage] Release yaml does not contain release \'version\'. Example: v1.1.2')
     }

--- a/src/test/groovy/edgeXReleaseGitTagUtilSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagUtilSpec.groovy
@@ -6,12 +6,6 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
     def edgeXReleaseGitTagUtil = null
     def validReleaseInfo
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXReleaseGitTagUtil = loadPipelineScriptForTest('vars/edgeXReleaseGitTagUtil.groovy')
 
@@ -31,11 +25,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a name attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'name'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'name'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'name\'')
     }
@@ -43,11 +33,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a version attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'version'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'version'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'version\'')
     }
@@ -55,11 +41,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a releaseStream attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'releaseStream'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'releaseStream'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'releaseStream\'')
     }
@@ -67,11 +49,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a repo attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'repo'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'repo'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'repo\'')
     }

--- a/src/test/groovy/edgeXReleaseSnapSpec.groovy
+++ b/src/test/groovy/edgeXReleaseSnapSpec.groovy
@@ -7,12 +7,6 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     def validReleaseInfo
     def validSnapInfo
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXReleaseSnap = loadPipelineScriptForTest('vars/edgeXReleaseSnap.groovy')
 
@@ -74,11 +68,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a name attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'name'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'name'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'name\'')
     }
@@ -86,11 +76,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a version attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'version'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'version'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'version\'')
     }
@@ -98,11 +84,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a snapChannels attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'snapChannels'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'snapChannels'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'snapChannels\'')
     }
@@ -110,11 +92,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a releaseStream attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'releaseStream'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'releaseStream'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'releaseStream\'')
     }    
@@ -122,11 +100,7 @@ public class EdgeXReleaseSnapSpec extends JenkinsPipelineSpecification {
     def "Test validate [Should] raise error [When] release info yaml does not have a repo attribute" () {
         setup:
         when:
-            try {
-                edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'repo'})
-            }
-            catch(TestException exception) {
-            }
+            edgeXReleaseSnap.validate(validReleaseInfo.findAll {it.key != 'repo'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseSnap]: Release yaml does not contain \'repo\'')
     }

--- a/src/test/groovy/edgeXSwaggerPublishSpec.groovy
+++ b/src/test/groovy/edgeXSwaggerPublishSpec.groovy
@@ -26,7 +26,7 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSwaggerPublish(apiFolders:'api/v1')
         then:
-            1 * getPipelineMock("libraryResource").call('edgex-publish-swagger.sh')
+            1 * getPipelineMock("libraryResource").call('edgex-publish-swagger.sh') >> 'edgex-public-swagger-script'
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                 def envArgs = [
                     'SWAGGER_DRY_RUN=true',
@@ -35,6 +35,7 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
                 ]
                 assert envArgs == _arguments[0][0]
             }
+            1 * getPipelineMock('sh').call(script: 'edgex-public-swagger-script')
     }
 
     def "Test edgeXSwaggerPublish [Should] call shell script with expected arguments [When] owner is provided" () {
@@ -43,7 +44,7 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSwaggerPublish(owner: 'Moby', apiFolders:'openapi/v1 openapi/v2')
         then:
-            1 * getPipelineMock("libraryResource").call('edgex-publish-swagger.sh')
+            1 * getPipelineMock("libraryResource").call('edgex-publish-swagger.sh') >> 'edgex-public-swagger-script'
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                 def envArgs = [
                     'SWAGGER_DRY_RUN=false',
@@ -52,6 +53,7 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
                 ]
                 assert envArgs == _arguments[0][0]
             }
+            1 * getPipelineMock('sh').call(script: 'edgex-public-swagger-script')
     }
 
     def "Test edgeXSwaggerPublish [Should] should execute shell script correctly [When] DRY_RUN is true" () {
@@ -60,6 +62,7 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSwaggerPublish(apiFolders: 'openapi/v1 openapi/v2 custom_api')
         then:
+            1 * getPipelineMock("libraryResource").call('edgex-publish-swagger.sh') >> 'edgex-public-swagger-script'
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                 def envArgs = [
                     'SWAGGER_DRY_RUN=true',
@@ -68,6 +71,7 @@ public class EdgeXSwaggerPublishSpec extends JenkinsPipelineSpecification {
                 ]
                 assert envArgs == _arguments[0][0]
             }
+            1 * getPipelineMock('sh').call(script: 'edgex-public-swagger-script')
     }
 
 }

--- a/src/test/groovy/edgeXUpdateNamedTagSpec.groovy
+++ b/src/test/groovy/edgeXUpdateNamedTagSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXUpdateNamedTagSpec extends JenkinsPipelineSpecification {
     
     def edgeXUpdateNamedTag = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeXUpdateNamedTag = loadPipelineScriptForTest('vars/edgeXUpdateNamedTag.groovy')
 
@@ -21,11 +15,7 @@ public class EdgeXUpdateNamedTagSpec extends JenkinsPipelineSpecification {
         setup:
             getPipelineMock('edgex.isDryRun').call() >> true
         when:
-            try {
-                edgeXUpdateNamedTag()
-            }
-            catch(TestException exception) {
-            }
+            edgeXUpdateNamedTag()
         then:
             1 * getPipelineMock('error').call('[edgeXUpdateNamedTag]: Original version (ogVersion) is required for the update named tag script.')
     }
@@ -34,11 +24,7 @@ public class EdgeXUpdateNamedTagSpec extends JenkinsPipelineSpecification {
         setup:
             getPipelineMock('edgex.isDryRun').call() >> true
         when:
-            try {
-                edgeXUpdateNamedTag('0.0.0')
-            }
-            catch(TestException exception) {
-            }
+            edgeXUpdateNamedTag('0.0.0')
         then:
             1 * getPipelineMock('error').call('[edgeXUpdateNamedTag]: Named version (namedVersion) is required for the update named tag script.')
     }

--- a/src/test/groovy/edgexSpec.groovy
+++ b/src/test/groovy/edgexSpec.groovy
@@ -5,12 +5,6 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
 
     def edgeX = null
 
-    public static class TestException extends RuntimeException {
-        public TestException(String _message) { 
-            super( _message );
-        }
-    }
-
     def setup() {
         edgeX = loadPipelineScriptForTest('vars/edgex.groovy')
         explicitlyMockPipelineVariable('out')
@@ -544,11 +538,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
     def "Test parseBuildCommit [Should] raise error [When] no matches are found" () {
         setup:
         when:
-            try {
-                edgeX.parseBuildCommit('release(geneva): Release Device Grove C service (1.2.0) and Testing frameworks (1.2.1)')
-            }
-            catch(TestException exception) {
-            }
+            edgeX.parseBuildCommit('release(geneva): Release Device Grove C service (1.2.0) and Testing frameworks (1.2.1)')
         then:
             1 * getPipelineMock('error').call('[edgex.parseBuildCommit]: No matches found.')
     }
@@ -556,11 +546,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
     def "Test parseBuildCommit [Should] raise error [When] no matches are found" () {
         setup:
         when:
-            try {
-                edgeX.parseBuildCommit('Merge pull request #46 from lranjbar/geneva-release')
-            }
-            catch(TestException exception) {
-            }
+            edgeX.parseBuildCommit('Merge pull request #46 from lranjbar/geneva-release')
         then:
             1 * getPipelineMock('error').call('[edgex.parseBuildCommit]: No matches found.')
     }
@@ -568,11 +554,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
     def "Test parseBuildCommit [Should] raise error [When] no matches are found" () {
         setup:
         when:
-            try {
-                edgeX.parseBuildCommit('release(geneva dot): Release App Service Configurable to latest track')
-            }
-            catch(TestException exception) {
-            }
+            edgeX.parseBuildCommit('release(geneva dot): Release App Service Configurable to latest track')
         then:
             1 * getPipelineMock('error').call('[edgex.parseBuildCommit]: No matches found.')
     }
@@ -580,11 +562,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
     def "Test parseBuildCommit [Should] raise error [When] no matches are found" () {
         setup:
         when:
-            try {
-                edgeX.parseBuildCommit('Merge pull request #46 from lranjbar/build(hanoi): release')
-            }
-            catch(TestException exception) {
-            }
+            edgeX.parseBuildCommit('Merge pull request #46 from lranjbar/build(hanoi): release')
         then:
             1 * getPipelineMock('error').call('[edgex.parseBuildCommit]: No matches found.')
     }
@@ -592,11 +570,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
     def "Test parseBuildCommit [Should] raise error [When] no matches are found" () {
         setup:
         when:
-            try {
-                edgeX.parseBuildCommit('build(hanoi): [1.2.0-dev.1,1.0.0] Stage Artifacts for edgex-go')
-            }
-            catch(TestException exception) {
-            }
+            edgeX.parseBuildCommit('build(hanoi): [1.2.0-dev.1,1.0.0] Stage Artifacts for edgex-go')
         then:
             1 * getPipelineMock('error').call('[edgex.parseBuildCommit]: No matches found.')
     }

--- a/vars/edgeXSetupEnvironment.groovy
+++ b/vars/edgeXSetupEnvironment.groovy
@@ -21,7 +21,7 @@ def call(vars) {
 
     def gitEnvVars = ['GIT_BRANCH', 'GIT_COMMIT']
     gitEnvVars.each { var ->
-        value = env[var]
+        value = env."${var}"
         vars[var] = value
 
         if(var == 'GIT_BRANCH') {
@@ -38,6 +38,6 @@ def call(vars) {
 
     vars.each { var, value ->
         println "[edgeXSetupEnvironment]: set envvar ${var} = ${value}"
-        env[var] = value
+        env."${var}" = value
     }
 }


### PR DESCRIPTION
- Continuing with the theme of removing unnecessary mocks; wrapping tests with try/catch when testing error was unnecessary. I removed the unneeded code and all tests passed.
- Also updated error mocks to check for explicit message.
- Reverted `edgeXSetupEnvironment` to use idiom for setting environment variables that doesn't incur a `RejectedAccessException` in EdgeX Jenkins
- Added missing mocks for `sh` in `edgeXSwaggerPublishSpec`

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
NA

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
```
# gradle clean test
Starting a Gradle Daemon, 1 incompatible and 2 stopped Daemons could not be reused, use --status for details

> Task :test
Results: SUCCESS (188 tests, 186 successes, 0 failures, 2 skipped)

BUILD SUCCESSFUL in 3m 5s
5 actionable tasks: 5 executed
```