### PR TITLE
Switch to lfInfraShipLogs, from LF Pipelines lib

### DIFF
--- a/src/test/groovy/edgeXInfraPublishSpec.groovy
+++ b/src/test/groovy/edgeXInfraPublishSpec.groovy
@@ -8,7 +8,7 @@ public class EdgeXInfraPublishSpec extends JenkinsPipelineSpecification {
     def setup() {
         edgeXInfraPublish = loadPipelineScriptForTest('vars/edgeXInfraPublish.groovy')
         explicitlyMockPipelineVariable('out')
-        explicitlyMockPipelineVariable('edgeXInfraShipLogs')
+        explicitlyMockPipelineVariable('lfInfraShipLogs')
     }
 
     def "Test edgeXInfraPublish [Should] call expected shell scripts with expected arguments [When] called" () {

--- a/vars/edgeXInfraPublish.groovy
+++ b/vars/edgeXInfraPublish.groovy
@@ -1,3 +1,4 @@
+import org.jenkinsci.plugins.workflow.libs.Library
 //
 // Copyright (c) 2019 Intel Corporation
 //
@@ -13,11 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+@Library("lf-pipelines") _
 
 def call(body) {
     // evaluate the body block, and collect configuration into the object
     def config = [:]
-    
+
     if(body) {
         body.resolveStrategy = Closure.DELEGATE_FIRST
         body.delegate = config
@@ -34,7 +36,7 @@ def call(body) {
         sh(script: libraryResource('global-jjb-shell/package-listing.sh'))
 
         // lf-infra-ship-logs
-        edgeXInfraShipLogs {
+        lfInfraShipLogs {
             logSettingsFile = _logSettingsFile
         }
 


### PR DESCRIPTION
Using the lfInfraShipLogs function will enable the collection of job
cost data, and keep the function up to date with global-jjb.

Issue: LF-Jira RELENG-3175
Signed-off-by: Eric Ball <eball@linuxfoundation.org>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Tested here: https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgexfoundry/job/sample-service/job/master/2/
Job 3 was also a test of this change, without the @Library line (I wasn't sure if it was necessary with the library added at the org level, but it turns out it is).

## Are there any new imports or modules? If so, what are they used for and why?
This adds an import of the lf-pipelines library, which needs to be added to the org to function. I added it on the sandbox, and will add it in prod once this is approved. The library can be found here: https://github.com/lfit/releng-pipelines

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
