### PR TITLE
revert: Disable Snap arm64 stage

### DIFF
--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -224,25 +224,26 @@ def call(config) {
                                 }
                             }
 
-                            stage('Snap') {
-                                agent {
-                                    node {
-                                        label 'ubuntu18.04-docker-arm64-16c-16g'
-                                        customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
-                                    }
-                                }
-                                when {
-                                    beforeAgent true
-                                    allOf {
-                                        environment name: 'BUILD_SNAP', value: 'true'
-                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
-                                        expression { !edgex.isReleaseStream() }
-                                    }
-                                }
-                                steps {
-                                    edgeXSnap(jobType: 'build')
-                                }
-                            }
+                            // Turning off arm64 Snap stage Per WG meeting 08/27/20
+                            // stage('Snap') {
+                            //     agent {
+                            //         node {
+                            //             label 'ubuntu18.04-docker-arm64-16c-16g'
+                            //             customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
+                            //         }
+                            //     }
+                            //     when {
+                            //         beforeAgent true
+                            //         allOf {
+                            //             environment name: 'BUILD_SNAP', value: 'true'
+                            //             expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                            //             expression { !edgex.isReleaseStream() }
+                            //         }
+                            //     }
+                            //     steps {
+                            //         edgeXSnap(jobType: 'build')
+                            //     }
+                            // }
                         }
                     }
                 }


### PR DESCRIPTION
Per the WG meeting today 08/27/2020 we are disabling the Snap stage for `edgeXBuildGoParallel`.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
