### PR TITLE
feat: add new option for Go 1.15 base image

### DIFF
--- a/src/test/groovy/edgexSpec.groovy
+++ b/src/test/groovy/edgexSpec.groovy
@@ -602,6 +602,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
                 '1.11',
                 '1.12',
                 '1.13',
+                '1.15',
                 '1.01',
                 'MyVersion'
             ]
@@ -609,6 +610,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
                 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.11.13-alpine',
                 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.12.14-alpine',
                 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine',
+                'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine',
                 'golang:1.01-alpine',
                 'golang:MyVersion-alpine'
             ]
@@ -623,6 +625,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
                 '1.11',
                 '1.12',
                 '1.13',
+                '1.15',
                 '1.01',
                 'MyVersion'
             ]
@@ -630,6 +633,7 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
                 'golang:1.11',
                 'golang:1.12',
                 'golang:1.13',
+                'golang:1.15',
                 'golang:1.01',
                 'golang:MyVersion'
             ]

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -211,7 +211,8 @@ def getGoLangBaseImage(version, alpineBased) {
         def goBaseImages = [
             '1.11': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.11.13-alpine',
             '1.12': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.12.14-alpine',
-            '1.13': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine'
+            '1.13': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine',
+            '1.15': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine'
         ]
 
         baseImage = goBaseImages[version]


### PR DESCRIPTION
To support developers in Go 1.15, we have added a new image to ci-build-images: https://github.com/edgexfoundry/ci-build-images/tree/golang-1.15. This PR adds the option to use this base image.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
