### PR TITLE
feat: update default version of Go to 1.15

### DIFF
--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -65,7 +65,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
             edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
             getPipelineMock('edgex.defaultTrue').call(_) >> true
             getPipelineMock('edgex.defaultFalse').call(_) >> false
-            getPipelineMock('edgex.getGoLangBaseImage').call(_) >> 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine'
+            getPipelineMock('edgex.getGoLangBaseImage').call(_) >> 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine'
         expect:
             edgeXBuildGoApp.toEnvironment(config) == expectedResult
         where:
@@ -81,8 +81,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     USE_SEMVER: true,
                     TEST_SCRIPT: 'make test',
                     BUILD_SCRIPT: 'make build',
-                    GO_VERSION: '1.13',
-                    DOCKER_BASE_IMAGE: 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine',
+                    GO_VERSION: '1.15',
+                    DOCKER_BASE_IMAGE: 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine',
                     DOCKER_FILE_PATH: 'Dockerfile',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -42,7 +42,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                 'ARCH': 'arm64',
                 'DOCKER_REGISTRY': 'nexus3.edgexfoundry.org',
                 'http_proxy': 'MyHttpProxy',
-                'DOCKER_BASE_IMAGE': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine',
+                'DOCKER_BASE_IMAGE': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine',
                 'DOCKER_BUILD_FILE_PATH': 'MyDockerBuildFilePath',
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
@@ -52,7 +52,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
         then:
             1 * getPipelineMock('docker.build').call([
                     'ci-base-image-arm64', 
-                    '-f MyDockerBuildFilePath  --build-arg BASE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base-arm64:1.13-alpine --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
+                    '-f MyDockerBuildFilePath  --build-arg BASE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base-arm64:1.15-alpine --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
     }
 
     def "Test validate [Should] raise error [When] config does not include a project parameter" () {
@@ -69,7 +69,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                 'SILO': 'sandbox'
             ]
             edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('edgex.getGoLangBaseImage').call(_) >> 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine'
+            getPipelineMock('edgex.getGoLangBaseImage').call(_) >> 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine'
         expect:
             edgeXBuildGoParallel.toEnvironment(config) == expectedResult
         where:
@@ -85,8 +85,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     USE_SEMVER: true,
                     TEST_SCRIPT: 'make test',
                     BUILD_SCRIPT: 'make build',
-                    GO_VERSION: '1.13',
-                    DOCKER_BASE_IMAGE: 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.13-alpine',
+                    GO_VERSION: '1.15',
+                    DOCKER_BASE_IMAGE: 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-golang-base:1.15-alpine',
                     DOCKER_FILE_GLOB: 'cmd/**/Dockerfile',
                     DOCKER_IMAGE_NAME_PREFIX: 'docker-',
                     DOCKER_IMAGE_NAME_SUFFIX: '-go',

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -430,7 +430,7 @@ def toEnvironment(config) {
     def _useSemver     = edgex.defaultTrue(config.semver)
     def _testScript    = config.testScript ?: 'make test'
     def _buildScript   = config.buildScript ?: 'make build'
-    def _goVersion     = config.goVersion ?: '1.13'
+    def _goVersion     = config.goVersion ?: '1.15'
     def _goProxy       = config.goProxy ?: 'https://nexus3.edgexfoundry.org/repository/go-proxy/'
     def _useAlpine     = edgex.defaultTrue(config.useAlpineBase)
 

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -410,7 +410,7 @@ def toEnvironment(config) {
     def _useSemver       = edgex.defaultTrue(config.semver)
     def _testScript      = config.testScript ?: 'make test'
     def _buildScript     = config.buildScript ?: 'make build'
-    def _goVersion       = config.goVersion ?: '1.13'
+    def _goVersion       = config.goVersion ?: '1.15'
     def _useAlpine       = edgex.defaultTrue(config.useAlpineBase)
     def _dockerBaseImage = edgex.getGoLangBaseImage(_goVersion, _useAlpine)
 


### PR DESCRIPTION
Make the default Go version 1.15 unless overridden by user.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
