### PR TITLE
(fix) allow yml as well as yaml extension to be used with edgex-publish-swagger

### DIFF
--- a/resources/edgex-publish-swagger.sh
+++ b/resources/edgex-publish-swagger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+shopt -s extglob
 # Environment Variables need to be set to call this shell script:
 # Owner: The username on swaggerhub where this API will be pushed.
 # apiFolder: A string of space delimited paths to API folders. Each .yaml file inside of this folder will be pushed to SwaggerHub.
@@ -18,9 +18,9 @@ publishToSwagger() {
     echo "[publishToSwagger] Publishing the API Docs [${apiFolder}] to Swagger"
 
     if [ -d "$apiPath" ]; then
-        for file in "${apiPath}"/*.yaml; do
+        for file in "${apiPath}"/*.+(yml|yaml); do
             apiName=$(basename "${file}" | cut -d "." -f 1)
-            apiContent=$(cat "${apiPath}/${apiName}".yaml)
+            apiContent=$(cat "${file}")
 
             echo "[publishToSwagger] Publishing API Name [$apiName]"
 


### PR DESCRIPTION
(fix) allow yml as well as yaml extension to be used with edgex-publish-swagger

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#237 
## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

Closes #237 
