### PR TITLE
refactor: move go version to prep stage

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -108,6 +108,7 @@ def call(config) {
                                             unstash 'semver'
                                         }
                                         prepBaseBuildImage()
+                                        sh 'go version'
                                     }
                                 }
                             }
@@ -119,7 +120,6 @@ def call(config) {
                                 steps {
                                     script {
                                         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
-                                            sh 'go version'
                                             sh "${TEST_SCRIPT}"
                                             stash name: 'coverage-report', includes: '**/*coverage.out', useDefaultExcludes: false, allowEmpty: true
                                         }
@@ -198,6 +198,7 @@ def call(config) {
                                             unstash 'semver'
                                         }
                                         prepBaseBuildImage()
+                                        sh 'go version'
                                     }
                                 }
                             }
@@ -209,7 +210,6 @@ def call(config) {
                                 steps {
                                     script {
                                         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
-                                            sh 'go version'
                                             sh "${TEST_SCRIPT}"
                                             stash name: 'coverage-report', includes: '**/*coverage.out', useDefaultExcludes: false, allowEmpty: true
                                         }

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -83,6 +83,7 @@ def call(config) {
                                     script {
                                         // builds ci-base-image used to cache dependencies and system libs
                                         prepBaseBuildImage()
+                                        sh 'go version'
                                     }
                                 }
                             }
@@ -98,7 +99,6 @@ def call(config) {
                                         docker.image("ci-base-image-${env.ARCH}")
                                             .inside('-u 0:0 -e GOTESTFLAGS= -v /var/run/docker.sock:/var/run/docker.sock --privileged')
                                         {
-                                            sh 'go version'
                                             testAndVerify()
                                         }
                                     }
@@ -176,6 +176,7 @@ def call(config) {
                                             unstash 'semver'
                                         }
                                         prepBaseBuildImage()
+                                        sh 'go version'
                                     }
                                 }
                             }
@@ -191,7 +192,6 @@ def call(config) {
                                         docker.image("ci-base-image-${env.ARCH}")
                                             .inside('-u 0:0 -e GOTESTFLAGS= -v /var/run/docker.sock:/var/run/docker.sock --privileged')
                                         {
-                                            sh 'go version'
                                             testAndVerify()
                                         }
                                     }


### PR DESCRIPTION
Move the `go version` to the prep stage to always print the go version into the Jenkins log.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
