### PR TITLE
Add condition for calling edgeXUpdateNamedTag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,15 @@ pipeline {
         }
 
         stage('Semver Bump Pre-Release Version') {
-            when { expression { env.BRANCH_NAME =~ /^master$/ } }
+            when {
+                allOf {
+                    expression { env.BRANCH_NAME =~ /^master$/ }
+                    // env.GITSEMVER_HEAD_TAG is only set when HEAD is tagged and
+                    // when set - edgeXSemver will ignore all tag, bump and push commands (unforced)
+                    // thus we also want to ignore updating stable/experimental tags when set
+                    expression { env.GITSEMVER_HEAD_TAG == null }
+                }
+            }
             steps {
                 edgeXSemver('bump patch') //this changes the VERSION env var
                 edgeXSemver('push')
@@ -112,7 +120,15 @@ pipeline {
 
         // automatically bump experimental tag...more research needed
         stage('🧪 Bump Experimental Tag') {
-            when { expression { env.BRANCH_NAME =~ /^master$/ } }
+            when {
+                allOf {
+                    expression { env.BRANCH_NAME =~ /^master$/ }
+                    // env.GITSEMVER_HEAD_TAG is only set when HEAD is tagged and
+                    // when set - edgeXSemver will ignore all tag, bump and push commands (unforced)
+                    // thus we also want to ignore updating stable/experimental tags when set
+                    expression { env.GITSEMVER_HEAD_TAG == null }
+                }
+            }
             steps {
                 script {
                     edgeXUpdateNamedTag(env.OG_VERSION, 'experimental')

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -368,6 +368,10 @@ def call(config) {
                             allOf {
                                 environment name: 'BUILD_EXPERIMENTAL_DOCKER_IMAGE', value: 'true'
                                 expression { env.SEMVER_BRANCH =~ /^master$/ }
+                                // env.GITSEMVER_HEAD_TAG is only set when HEAD is tagged and
+                                // when set - edgeXSemver will ignore all tag, bump and push commands (unforced)
+                                // thus we also want to ignore updating stable/experimental tags when set
+                                expression { env.GITSEMVER_HEAD_TAG == null }
                             }
                         }
                         steps {
@@ -381,6 +385,10 @@ def call(config) {
                             allOf {
                                 environment name: 'BUILD_STABLE_DOCKER_IMAGE', value: 'true'
                                 expression { env.SEMVER_BRANCH =~ /^master$/ }
+                                // env.GITSEMVER_HEAD_TAG is only set when HEAD is tagged and
+                                // when set - edgeXSemver will ignore all tag, bump and push commands (unforced)
+                                // thus we also want to ignore updating stable/experimental tags when set
+                                expression { env.GITSEMVER_HEAD_TAG == null }
                             }
                         }
                         steps {


### PR DESCRIPTION

Add an additional condition for when `edgeXUpdateNamedTag` is executed within our Pipelines.  Because `edgeXUpdateNamedTag` updates the experimental/stable tag on the version tag **it should only** execute when **edgeXSemver** creates the version tag.
To enable jobs to be executed repeatedly without the affect of tagging/bumping a new version tag every time; **edgeXSemver** sets the environment variable `env.GITSEMVER_HEAD_TAG` when it detects that HEAD is tagged, doing so, directs edgeXSemver to ignore all subsequent tag, bump and push commands (unforced). Thus if this environment variable is set then we should not call `edgeXUpdateNamedTag` because the new version tag will not exist.


Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
Fixes: https://github.com/edgexfoundry/git-semver/issues/47

## Sandbox Testing
NA

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
```
# gradle clean test
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details

> Task :test
Results: SUCCESS (202 tests, 200 successes, 0 failures, 2 skipped)

BUILD SUCCESSFUL in 3m 15s
5 actionable tasks: 5 executed
```