### PR TITLE
Update edgeXSemver to resolve semver tag issue

### DIFF
--- a/src/test/groovy/edgeXReleaseGitTagSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagSpec.groovy
@@ -59,7 +59,7 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
         when:
             edgeXReleaseGitTag.setAndSignGitTag('sample-service', '1.2.3')
         then:
-            1 * getPipelineMock('edgeXSemver.call')('init -ver=1.2.3 -force')
+            1 * getPipelineMock('edgeXSemver.call')('init', '1.2.3')
             1 * getPipelineMock('edgeXSemver.call')('tag -force')
             1 * getPipelineMock('dir').call(_) >> { _arguments ->
                 assert 'sample-service' == _arguments[0][0]
@@ -73,7 +73,8 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
         when:
             edgeXReleaseGitTag.setAndSignGitTag('sample-service', '1.2.3')
         then:
-            1 * getPipelineMock('echo').call('edgeXSemver init -ver=1.2.3 -force\nedgeXSemver tag -force')
+            1 * getPipelineMock('echo').call("edgeXSemver init 1.2.3")
+            1 * getPipelineMock('echo').call("edgeXSemver tag -force")
             1 * getPipelineMock('edgeXReleaseGitTagUtil.signGitTag').call('1.2.3', 'sample-service')
     }
 

--- a/src/test/groovy/edgeXSemverSpec.groovy
+++ b/src/test/groovy/edgeXSemverSpec.groovy
@@ -10,7 +10,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         explicitlyMockPipelineVariable('out')
     }
 
-    def "Test edgeXSemver [Should] call expected and set VERSION envvar [When] called with no command" () {
+    def "Test edgeXSemver [Should] call expected and set VERSION [When] no command" () {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
@@ -22,7 +22,18 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
             environmentVariables['VERSION'] == '1.2.3-dev.4'
     }
 
-    def "Test edgeXSemver [Should] call expected and set VERSION envvar [When] called with init command, semverVersion and GITSEMVER_HEAD_TAG is set" () {
+    def "Test edgeXSemver [Should] return expected [When] no command" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')([script: 'git semver', returnStdout: true]) >> '1.2.3-dev.4\n'
+        expect:
+            def result = edgeXSemver()
+            result == '1.2.3-dev.4'
+    }
+
+    def "Test edgeXSemver [Should] call expected and set VERSION [When] command is init and semverVersion and GITSEMVER_HEAD_TAG is set" () {
         setup:
             def environmentVariables = [
                 'GITSEMVER_HEAD_TAG': 'MyTag'
@@ -51,9 +62,12 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
             environmentVariables['VERSION'] == '1.2.4'
             // verify writefile
             1 * getPipelineMock('writeFile').call([file: 'VERSION', text: '1.2.4'])
+            // should not call get tag to determine if HEAD is tagged since GITSEMVER_HEAD_TAG is set
+            0 * getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true])
+            environmentVariables['GITSEMVER_INIT_VERSION'] == '1.2.4'
     }
 
-    def "Test edgeXSemver [Should] get semver version from command and set VERSION envvar [When] called with init command" () {
+    def "Test edgeXSemver [Should] call expected and set VERSION [When] called with init command and GITSEMVER_HEAD_TAG is set" () {
         setup:
             def environmentVariables = [
                 'GITSEMVER_HEAD_TAG': 'MyTag'
@@ -63,74 +77,295 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
             edgeXSemver('init')
         then:
             1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+
+            1 * getPipelineMock('echo')("[edgeXSemver]: GITSEMVER_HEAD_TAG is already set to 'MyTag'")
+
+            1 * getPipelineMock('sh').call('git semver init')
+
             1 * getPipelineMock('sh').call([script: 'git semver', returnStdout: true]) >> '1.2.3-dev.4\n'
             environmentVariables['VERSION'] == '1.2.3-dev.4'
     }
 
-    @Ignore
-    def "Test edgeXSemver [Should] call expected [When] called with tag force command and GITSEMVER_HEAD_TAG is set" () {
+    def "Test edgeXSemver [Should] ignore command, call expected and set VERSION [When] called with non init command and GITSEMVER_HEAD_TAG is set" () {
         setup:
             def environmentVariables = [
-                'GITSEMVER_HEAD_TAG': 'MyTag'
+                'GITSEMVER_HEAD_TAG': 'v1.0.3-dev.3'
             ]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
         when:
-            edgeXSemver('tag -force')
+            edgeXSemver('tag')
         then:
-            // TODO: this is a bug - tag force is not being executed because GITSEMVER_HEAD_TAG is set
-            // https://github.com/edgexfoundry/cd-management/issues/55
+            1 * getPipelineMock('echo')("[edgeXSemver]: ignoring command tag because GITSEMVER_HEAD_TAG is already set to 'v1.0.3-dev.3'")
+
             1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
-            1 * getPipelineMock('sh').call('git semver tag -force')
+
             1 * getPipelineMock('sh').call([script: 'git semver', returnStdout: true]) >> '1.2.3-dev.4\n'
+            environmentVariables['VERSION'] == '1.2.3-dev.4'
     }
 
-    def "Test executeSSH [Should] call sshagent and sh with the expected arguments [When] called" () {
+    def "Test edgeXSemver [Should] call command and set GITSEMVER_HEAD_TAG [When] command is init and no semverVersion" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> 'v1.2.3'
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('init')
+        then:
+            1 * getPipelineMock('echo')("[edgeXSemver]: set GITSEMVER_HEAD_TAG to 'v1.2.3'")
+            1 * getPipelineMock('sh').call('git semver init')
+            environmentVariables['GITSEMVER_HEAD_TAG'] == 'v1.2.3'
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] call command and not set GITSEMVER_HEAD_TAG [When] command is init and semverVersion" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+        when:
+            edgeXSemver('init', '2.3.4')
+        then:
+            0 * getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true)
+            1 * getPipelineMock('sh').call('git semver init -ver=2.3.4 -force')
+            environmentVariables.containsKey('GITSEMVER_HEAD_TAG') == false
+            environmentVariables['VERSION'] == '2.3.4'
+            environmentVariables['GITSEMVER_INIT_VERSION'] == '2.3.4'
+    }
+
+    def "Test edgeXSemver [Should] call command and not set GITSEMVER_HEAD_TAG [When] command is init ver force and not semverVersion" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            // TODO: I'm not convinced this should be supported - specify semverVersion if specific version is to be specified
+            edgeXSemver('init -ver=2.3.4 -force')
+        then:
+            0 * getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true)
+            1 * getPipelineMock('sh').call('git semver init -ver=2.3.4 -force')
+            environmentVariables.containsKey('GITSEMVER_HEAD_TAG') == false
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] not call command [When] command is tag and GITSEMVER_HEAD_TAG is set" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_HEAD_TAG': '1.2.3'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('tag')
+        then:
+            1 * getPipelineMock('echo')("[edgeXSemver]: ignoring command tag because GITSEMVER_HEAD_TAG is already set to '1.2.3'")
+            0 * getPipelineMock('sh').call('git semver tag')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] call command [When] command is tag and GITSEMVER_HEAD_TAG is not set and GITSEMVER_INIT_VERSION not in HEAD tags" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> ''
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('tag')
+        then:
+            1 * getPipelineMock('sh').call('git semver tag')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] not call command [When] command is tag and GITSEMVER_HEAD_TAG is not set and GITSEMVER_INIT_VERSION is in HEAD tags" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_INIT_VERSION': '1.2.3'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> 'v1.2.3'
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('tag')
+        then:
+            1 * getPipelineMock('echo')("[edgeXSemver]: HEAD is already tagged with 1.2.3")
+            0 * getPipelineMock('sh').call('git semver tag')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] not call command [When] command is tag force and GITSEMVER_HEAD_TAG is not set and GITSEMVER_INIT_VERSION is not in HEAD tags" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_INIT_VERSION': '1.2.3'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> ''
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.3'
+        when:
+            edgeXSemver('tag -force')
+        then:
+            0 * getPipelineMock('echo')("[edgeXSemver]: HEAD is already tagged with 1.2.3")
+            1 * getPipelineMock('echo')("[edgeXSemver]: removing remote and local tags for 1.2.3")
+            1 * getPipelineMock('sh').call('git semver tag -force')
+            environmentVariables['VERSION'] == '1.2.3'
+    }
+
+    def "Test edgeXSemver [Should] call command [When] command is bump and GITSEMVER_HEAD_TAG is not set" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('bump pre')
+        then:
+            1 * getPipelineMock('sh').call('git semver bump pre')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] not call command [When] command is bump and GITSEMVER_HEAD_TAG is set" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_HEAD_TAG': '1.2.4-dev.1'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('bump pre')
+        then:
+            1 * getPipelineMock('echo')("[edgeXSemver]: ignoring command bump pre because GITSEMVER_HEAD_TAG is already set to '1.2.4-dev.1'")
+            0 * getPipelineMock('sh').call('git semver bump pre')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] call command [When] command is push and GITSEMVER_HEAD_TAG is not set" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('push')
+        then:
+            1 * getPipelineMock('sh').call('git semver push')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test edgeXSemver [Should] not call command [When] command is push and GITSEMVER_HEAD_TAG is set" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_HEAD_TAG': '1.2.4-dev.1'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
+        when:
+            edgeXSemver('push')
+        then:
+            1 * getPipelineMock('echo')("[edgeXSemver]: ignoring command push because GITSEMVER_HEAD_TAG is already set to '1.2.4-dev.1'")
+            0 * getPipelineMock('sh').call('git semver push')
+            environmentVariables['VERSION'] == '1.2.4-dev.1'
+    }
+
+    def "Test executeGitSemver [Should] call sshagent and sh with the expected arguments [When] called" () {
         setup:
         when:
-            edgeXSemver.executeSSH('MyCredentials', 'MyCommand')
-        then:   
+            edgeXSemver.executeGitSemver('MyCredentials', 'git semver bump pre')
+        then:
             1 * getPipelineMock('sshagent').call(_) >> { _arguments ->
                 assert ['credentials':['MyCredentials']] == _arguments[0][0]
             }
-            1 * getPipelineMock('sh').call('MyCommand')
+            1 * getPipelineMock('sh').call('git semver bump pre')
     }
 
-    def "Test setHeadTagEnv [Should] not call sshagent [When] GITSEMVER_HEAD_TAG environment variable is set" () {
+    def "Test executeGitSemver [Should] return and not call command [When] tag and HEAD is tagged with GITSEMVER_INIT_VERSION" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_INIT_VERSION': '1.2.3'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> 'v1.2.3'
+        when:
+            edgeXSemver.executeGitSemver('MyCredentials', 'git semver tag')
+        then:
+            1 * getPipelineMock('echo').call("[edgeXSemver]: HEAD is already tagged with 1.2.3")
+            0 * getPipelineMock('sh').call('git semver tag')
+    }
+
+    def "Test executeGitSemver [Should] delete remote and local tag and call command [When] tag force and HEAD is not tagged" () {
+        setup:
+            def environmentVariables = [
+                'GITSEMVER_INIT_VERSION': '1.2.3'
+            ]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> ''
+        when:
+            edgeXSemver.executeGitSemver('MyCredentials', 'git semver tag -force')
+        then:
+            // ugly to assert due to spaces after carriage returns
+            // 1 * getPipelineMock('sh').call('set +x\nset +e\ngit push origin :refs/tags/v1.2.3\ngit tag -d v1.2.3\nset -e\n')
+            1 * getPipelineMock('echo').call("[edgeXSemver]: removing remote and local tags for 1.2.3")
+            1 * getPipelineMock('sh').call('git semver tag -force')
+    }
+
+    def "Test setGitSemverHeadTag [Should] not call sshagent [When] GITSEMVER_HEAD_TAG is set" () {
         setup:
             def environmentVariables = [
                 'GITSEMVER_HEAD_TAG': 'MyGitsemverHeadTag'
             ]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
         when:
-            edgeXSemver.setHeadTagEnv('MyCredentials')
+            edgeXSemver.setGitSemverHeadTag('MyCredentials')
         then:
             0 * getPipelineMock('sshagent').call(_) 
     }
 
-    def "Test setHeadTagEnv [Should] query for and set GITSEMVER_HEAD_TAG environment variable [When] GITSEMVER_HEAD_TAG environment variable is not set" () {
+    def "Test setGitSemverHeadTag [Should] set GITSEMVER_HEAD_TAG [When] GITSEMVER_HEAD_TAG is not set and HEAD is tagged" () {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
         when:
-            edgeXSemver.setHeadTagEnv('MyCredentials')
+            edgeXSemver.setGitSemverHeadTag('MyCredentials')
         then:
             1 * getPipelineMock('sshagent').call(_) >> { _arguments ->
                 assert ['credentials':['MyCredentials']] == _arguments[0][0]
             }
-            1 * getPipelineMock('sh')([script:'git describe --exact-match --tags HEAD', returnStdout:true]) >> 'MyTag\n'
-            environmentVariables['GITSEMVER_HEAD_TAG'] == 'MyTag'
+            1 * getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> 'v1.0.3\nexperimental'
+            environmentVariables['GITSEMVER_HEAD_TAG'] == 'v1.0.3|experimental'
     }
 
-    def "Test setHeadTagEnv [Should] not set GITSEMVER_HEAD_TAG environment variable [When] exception occurs within ssh" () {
+    def "Test setGitSemverHeadTag [Should] not set GITSEMVER_HEAD_TAG [When] GITSEMVER_HEAD_TAG is not set and HEAD is not tagged" () {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('sh')(_) >> {
-                throw new Exception('MockedException1')
-            }
+            getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> ''
         when:
-            edgeXSemver.setHeadTagEnv('MyCredentials')
+            edgeXSemver.setGitSemverHeadTag('MyCredentials')
         then:
             environmentVariables.containsKey('GITSEMVER_HEAD_TAG') == false
+    }
+
+    def "Test getHeadTags [Should] return expected list [When] HEAD is tagged" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> 'tag1\ntag2\ntag3'
+        expect:
+            edgeXSemver.getHeadTags('MyCredentials') == ['tag1', 'tag2', 'tag3']
+    }
+
+    def "Test getHeadTags [Should] return empty list [When] HEAD is not tagged" () {
+        setup:
+            def environmentVariables = [:]
+            edgeXSemver.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> ''
+        expect:
+            edgeXSemver.getHeadTags('MyCredentials') == []
     }
 }

--- a/vars/edgeXReleaseGitTag.groovy
+++ b/vars/edgeXReleaseGitTag.groovy
@@ -57,18 +57,14 @@ def cloneRepo(repo, branch, name, credentials) {
 def setAndSignGitTag(name, version) {
     // call edgeXSemver functions to force tag version and push
     println "[edgeXReleaseGitTag]: setting tag for ${name} to: ${version} - DRY_RUN: ${env.DRY_RUN}"
-    def commands = [
-        "init -ver=${version} -force",
-        "tag -force"
-    ]
     if(edgex.isDryRun()) {
-        echo(commands.collect {"edgeXSemver ${it}"}.join('\n'))
+        echo("edgeXSemver init ${version}")
+        echo("edgeXSemver tag -force")
     }
     else {
         dir("${name}") {
-            commands.each { command ->
-                edgeXSemver command
-            }
+            edgeXSemver('init', version)
+            edgeXSemver('tag -force')
         }
     }
     edgeXReleaseGitTagUtil.signGitTag(version, name)

--- a/vars/edgeXSemver.groovy
+++ b/vars/edgeXSemver.groovy
@@ -14,13 +14,14 @@
 // limitations under the License.
 //
 
-def call(command = null, semverVersion = '', gitSemverVersion = 'latest', credentials = 'edgex-jenkins-ssh', debug = true) {
+def call(command = null, semverVersion = '', gitSemverVersion = 'latest', credentials = 'edgex-jenkins-ssh') {
     def semverImage = env.ARCH && env.ARCH == 'arm64'
         ? "nexus3.edgexfoundry.org:10004/edgex-devops/git-semver-arm64:${gitSemverVersion}"
         : "nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:${gitSemverVersion}"
 
     def envVars = [
-        'SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts'
+        'SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts',
+        'SEMVER_DEBUG=on'
     ]
     def semverCommand = [
        'git',
@@ -33,33 +34,34 @@ def call(command = null, semverVersion = '', gitSemverVersion = 'latest', creden
         }
     }
     else {
-        if(debug) {
-            envVars << 'SEMVER_DEBUG=on'
-        }
         semverCommand << command
 
         // If semverVersion is passed in override the version from the .semver directory
         if (command == 'init' && semverVersion) {
             semverCommand << "-ver=${semverVersion}"
             semverCommand << "-force"
-
         }
 
         docker.image(semverImage).inside('-v /etc/ssh:/etc/ssh') {
             withEnv(envVars) {
                 if((env.GITSEMVER_HEAD_TAG) && (command != 'init')) {
-                    println "[edgeXSemver]: ignoring command ${command} because GITSEMVER_HEAD_TAG is already set to '${env.GITSEMVER_HEAD_TAG}'"
+                    // setting and checking GITSEMVER_HEAD_TAG is the pattern we implement to facilitate re-execution
+                    // of jobs without having semver unwantingly tag HEAD with the next version
+                    echo "[edgeXSemver]: ignoring command ${command} because GITSEMVER_HEAD_TAG is already set to '${env.GITSEMVER_HEAD_TAG}'"
                 }
                 else {
-                    if(command == 'init') {
-                        setHeadTagEnv(credentials)
+                    if((command == 'init') && (!semverVersion)) {
+                        // when a semverVersion is specified semver will force init the version and
+                        // we don't want to set GITSEMVER_HEAD_TAG since we don't want to ignore
+                        // any other subsequent git semver commands associated with the force init
+                        setGitSemverHeadTag(credentials)
                     }
-                    executeSSH(credentials, semverCommand.join(' '))
+                    executeGitSemver(credentials, semverCommand.join(' '))
                 }
             }
 
-            // If no version is passed in then get the next version from git semver
             if(!semverVersion) {
+                // if no specified version then get next version from git semver
                 semverVersion = sh(script: 'git semver', returnStdout: true).trim()
             }
         }
@@ -71,32 +73,72 @@ def call(command = null, semverVersion = '', gitSemverVersion = 'latest', creden
         writeFile file: 'VERSION', text: semverVersion
         stash name: 'semver', includes: '.semver/**,VERSION', useDefaultExcludes: false
         echo "[edgeXSemver]: initialized semver on version ${semverVersion}"
+
+        if(semverVersion) {
+            // set GITSEMVER_INIT_VERSION to initial specified version
+            env.GITSEMVER_INIT_VERSION = semverVersion
+        }
     }
 
     semverVersion
 }
 
-def executeSSH(credentials, command) {
-    // execute command via ssh with provided credentials considering noop mode
+def executeGitSemver(credentials, semverCommand) {
+    // execute semverCommand via ssh with provided credentials
     sshagent (credentials: [credentials]) {
-        sh command
+        if(semverCommand =~ '^.*tag.*$') {
+            // edgeXSemver sets specified semverVersion in the GITSEMVER_INIT_VERSION environment variable
+            def headTags = getHeadTags(credentials)
+            if(headTags.contains("v${env.GITSEMVER_INIT_VERSION}")) {
+                // if HEAD is already tagged with GITSEMVER_INIT_VERSION then return and do not execute the tag command
+                echo "[edgeXSemver]: HEAD is already tagged with ${env.GITSEMVER_INIT_VERSION}"
+                return
+            }
+            else {
+                if(semverCommand =~ '^.*-force$') {
+                    // HEAD is not tagged with GITSEMVER_INIT_VERSION
+                    // lets remove the GITSEMVER_INIT_VERSION tag from remote and local (if it exists)
+                    // so the tag command will not error with the tag already exists
+                    // this is an edge condition that only happens when user re-submits a build commit on same version
+                    echo "[edgeXSemver]: removing remote and local tags for ${env.GITSEMVER_INIT_VERSION}"
+                    sh """
+                        set +x
+                        set +e
+                        git push origin :refs/tags/${env.GITSEMVER_INIT_VERSION}
+                        git tag -d ${env.GITSEMVER_INIT_VERSION}
+                        set -e
+                    """
+                }
+            }
+        }
+        sh semverCommand
     }
 }
 
-def setHeadTagEnv(credentials) {
-    // set environment variable GITSEMVER_HEAD_TAG to value of tag at HEAD
+def setGitSemverHeadTag(credentials) {
+    // set GITSEMVER_HEAD_TAG to value of all tags at HEAD only if tagged
     if(env.GITSEMVER_HEAD_TAG) {
-        println "[edgeXSemver]: envvar GITSEMVER_HEAD_TAG is already set to '${env.GITSEMVER_HEAD_TAG}'"
-        return
+        echo "[edgeXSemver]: GITSEMVER_HEAD_TAG is already set to '${env.GITSEMVER_HEAD_TAG}'"
     }
-    try {
-        sshagent (credentials: [credentials]) {
-            def tag = sh(script: 'git describe --exact-match --tags HEAD', returnStdout: true).trim()
-            println "[edgeXSemver]: setting envvar GITSEMVER_HEAD_TAG value to \'${tag}\'"
-            env.GITSEMVER_HEAD_TAG = tag
+    else {
+        def headTags = getHeadTags(credentials)
+        if(headTags) {
+            def gitSemverHeadTags = headTags.join('|')
+            env.GITSEMVER_HEAD_TAG = gitSemverHeadTags
+            echo "[edgeXSemver]: set GITSEMVER_HEAD_TAG to \'${gitSemverHeadTags}\'"
         }
     }
-    catch(error) {
-        println "[edgeXSemver]: exception occurred checking if HEAD is tagged: ${error}\nThis usually means this commit has not been tagged."
+}
+
+def getHeadTags(credentials) {
+    // return list of all tags at HEAD
+    def headTags = []
+    def tags
+    sshagent (credentials: [credentials]) {
+        tags = sh(script: 'git tag --points-at HEAD', returnStdout: true).trim()
     }
+    if(tags) {
+        headTags = tags.split()
+    }
+    headTags
 }


### PR DESCRIPTION
**TESTING IN PROGRESS**

- Made `edgeXSemver` more robust by enabling it to handle use cases that were previously resulting in tag errors.
-- updated how to detect if HEAD is tagged and conditions for when to set GITSEMVER_HEAD_TAG which is used to facilitate re-execution of build jobs without having semver continue tagging
-- leverage GITSEMVER_INIT_VERSION to hold initial semver version
-- added logic to remove remote/local GITSEMVER_INIT_VERSION tag when force tag; specific edge case condition
-- converted prints to echo statements to facilitate assertions in unit tests
- Updated `edgeXBuildGoApp` and `edgeXReleaseGitTag` global functions to consume `edgeXSemver` in a standard way
- Added `edgeXSemverSpec` unit tests to test multiple `edgeXSemver` use cases

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X ] Tests for the changes have been added (for bug fixes / features)
- [X ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
Fixes: https://github.com/edgexfoundry/cd-management/issues/55

## Sandbox Testing

- Test multiple explicit `edgeXSemver` flows:
Tested multiple edgeXSemver flows using sample-service:
The Jenkinsfile is here:  https://github.com/edgexfoundry/sample-service/blob/master/Jenkinsfile.semver
The Jenkins Job is here: https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/77

- Test typical build using (4.1.15-dev.1) `edgeXBuildGoApp` -> `edgeXSemver`:
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/74

- Test re-execution of build:
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/80/

- Test a build initiated from a build commit (v4.1.14) `edgeXBuildGoApp` -> `edgeXSemver`:
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/72

- Test a build initiated from a build commit using existing version (v4.1.14):
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/73

- Test release using release automation (v4.1.16) `edgeXRelease` -> `edgeXReleaseGitTag` -> `edgeXSemver`
https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/cd-management/view/change-requests/job/PR-80/

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
```
# gradle clean test
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details

> Task :test
Results: SUCCESS (221 tests, 220 successes, 0 failures, 1 skipped)

BUILD SUCCESSFUL in 3m 19s
5 actionable tasks: 5 executed
```