### PR TITLE
feat(snap): Use new native build script

### DIFF
--- a/resources/snap-build.sh
+++ b/resources/snap-build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+echo "snap-build.sh"
+
+# assume building in the current directory
+SNAP_BASE_DIR=.
+
+if [ ! -z $WORKSPACE ]; then
+  SNAP_BASE_DIR=$WORKSPACE
+fi
+
+echo "[snap-build] Building snap in dir [$SNAP_BASE_DIR]"
+
+cd "$SNAP_BASE_DIR"
+
+# script to build the edgexfoundry snap on ubuntu
+# installs lxd, snapcraft, and then builds the snap 
+
+# remove lxd
+sudo apt-get remove -qy --purge lxd lxd-client
+sudo snap remove --purge lxd
+# set up lxd group
+sudo groupadd --force --system lxd
+sudo /usr/sbin/usermod -G lxd -a "$(whoami)"
+newgrp - lxd
+#install lxd
+sudo snap install lxd
+sudo lxd init --auto
+# install snapcraft
+sudo snap install --classic snapcraft
+
+if [ -f "snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch" ]; then
+  #patch the snapcraft.yml file
+  patch --verbose -p1 < snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
+fi
+
+# run snapcraft
+sudo snapcraft prime --use-lxd

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -175,7 +175,7 @@ def call(config) {
                             stage('Snap') {
                                 agent {
                                     node {
-                                        label 'centos7-docker-8c-8g'
+                                        label 'ubuntu18.04-docker-8c-8g'
                                         customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
                                     }
                                 }
@@ -189,7 +189,7 @@ def call(config) {
                                 }
                                 steps {
                                     script {
-                                        edgeXSnap(jobType: 'build')
+                                        edgeXSnap()
                                     }
                                 }
                             }
@@ -264,7 +264,8 @@ def call(config) {
                                 }
                             }
 
-                            stage('Snap') {
+                            // Turning off arm64 Snap stage Per WG meeting 10/29/20
+                            /*stage('Snap') {
                                 agent {
                                     node {
                                         label 'ubuntu18.04-docker-arm64-16c-16g'
@@ -281,10 +282,10 @@ def call(config) {
                                 }
                                 steps {
                                     script {
-                                        edgeXSnap(jobType: 'build')
+                                        edgeXSnap()
                                     }
                                 }
-                            }
+                            }*/
                         }
                     }
                 }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -203,7 +203,7 @@ def call(config) {
                             stage('Snap') {
                                 agent {
                                     node {
-                                        label 'centos7-docker-8c-8g'
+                                        label 'ubuntu18.04-docker-8c-8g'
                                         customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
                                     }
                                 }
@@ -216,7 +216,7 @@ def call(config) {
                                     }
                                 }
                                 steps {
-                                    edgeXSnap(jobType: 'build')
+                                    edgeXSnap()
                                 }
                             }
                         }
@@ -298,25 +298,25 @@ def call(config) {
                             }
 
                             // Turning off arm64 Snap stage Per WG meeting 10/29/20
-                            // stage('Snap') {
-                            //     agent {
-                            //         node {
-                            //             label 'ubuntu18.04-docker-arm64-16c-16g'
-                            //             customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
-                            //         }
-                            //     }
-                            //     when {
-                            //         beforeAgent true
-                            //         allOf {
-                            //             environment name: 'BUILD_SNAP', value: 'true'
-                            //             expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
-                            //             expression { !edgex.isReleaseStream() }
-                            //         }
-                            //     }
-                            //     steps {
-                            //         edgeXSnap(jobType: 'build')
-                            //     }
-                            // }
+                            /*stage('Snap') {
+                                agent {
+                                    node {
+                                        label 'ubuntu18.04-docker-arm64-16c-16g'
+                                        customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
+                                    }
+                                }
+                                when {
+                                    beforeAgent true
+                                    allOf {
+                                        environment name: 'BUILD_SNAP', value: 'true'
+                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                        expression { !edgex.isReleaseStream() }
+                                    }
+                                }
+                                steps {
+                                    edgeXSnap()
+                                }
+                            }*/
                         }
                     }
                 }

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -178,7 +178,7 @@ def call(config) {
                             stage('Snap') {
                                 agent {
                                     node {
-                                        label 'centos7-docker-8c-8g'
+                                        label 'ubuntu18.04-docker-8c-8g'
                                         customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
                                     }
                                 }
@@ -191,7 +191,7 @@ def call(config) {
                                     }
                                 }
                                 steps {
-                                    edgeXSnap(jobType: 'build')
+                                    edgeXSnap()
                                 }
                             }
                         }
@@ -274,25 +274,25 @@ def call(config) {
                             }
 
                             // Turning off arm64 Snap stage Per WG meeting 08/27/20
-                            // stage('Snap') {
-                            //     agent {
-                            //         node {
-                            //             label 'ubuntu18.04-docker-arm64-16c-16g'
-                            //             customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
-                            //         }
-                            //     }
-                            //     when {
-                            //         beforeAgent true
-                            //         allOf {
-                            //             environment name: 'BUILD_SNAP', value: 'true'
-                            //             expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
-                            //             expression { !edgex.isReleaseStream() }
-                            //         }
-                            //     }
-                            //     steps {
-                            //         edgeXSnap(jobType: 'build')
-                            //     }
-                            // }
+                            /*stage('Snap') {
+                                agent {
+                                    node {
+                                        label 'ubuntu18.04-docker-arm64-16c-16g'
+                                        customWorkspace "/w/workspace/${env.PROJECT}/${env.BUILD_ID}"
+                                    }
+                                }
+                                when {
+                                    beforeAgent true
+                                    allOf {
+                                        environment name: 'BUILD_SNAP', value: 'true'
+                                        expression { findFiles(glob: 'snap/snapcraft.yaml').length == 1 }
+                                        expression { !edgex.isReleaseStream() }
+                                    }
+                                }
+                                steps {
+                                    edgeXSnap()
+                                }
+                            }*/
                         }
                     }
                 }

--- a/vars/edgeXSnap.groovy
+++ b/vars/edgeXSnap.groovy
@@ -15,78 +15,11 @@
 //
 
 /* Usage
-edgeXSnap(
-    jobType: 'build|snapshot|release',
-    snapChannel: 'latest/edge|latest/snapshot', used for jobType = snapshot|release
-)
-
-Optional:
-
-snapRevision, some revision number (2049)... used for jobType = release
-snapName, name of the snap. If not provided, the snapcraft.yaml will be used to determine the name
-snapBuilderImage, which docker image to use to build the snap
-snapBase, the base directory where to build the snap
-snapStoreLoginSettings, the name of the Jenkins settings file with login details
+Wrapper around resources/snap-build.sh script.
+No parameters required.
+edgeXSnap()
 */
 
 def call(config = [:]) {
-    def _arch = env.ARCH ?: 'amd64'
-    def _snapBuilderVersion = config.snapBuilderVersion ?: 'latest'
-    def _snapBuilderImage = config.snapBuilderImage ?: "${DOCKER_REGISTRY}:10003/edgex-devops/edgex-snap-builder:${_snapBuilderVersion}"
-
-    // TODO: find a better way to do this
-    if(_arch == 'arm64') {
-        _snapBuilderImage = "${DOCKER_REGISTRY}:10003/edgex-devops/edgex-snap-builder-${_arch}:${_snapBuilderVersion}"
-    }
-
-    def _snapBase     = config.snapBase ?: env.WORKSPACE
-    def _jobType      = config.jobType ?: 'build'
-    def _snapChannel  = config.snapChannel ?: 'latest/edge'
-    def _snapRevision = config.snapRevision ?: ''
-    def _snapName     = config.snapName
-
-    def _snapStoreLoginSettings = config.snapStoreLoginSettings ?: 'EdgeX'
-
-    def envVars = []
-
-    envVars << "JOB_TYPE=${_jobType}"
-    envVars << "SNAP_REVISION=${_snapRevision}"
-    envVars << "SNAP_CHANNEL=${_snapChannel}"
-
-    // find the snapcraft.yaml in the snapBase dir and return the name of the snap if not specified
-    if(!_snapName) {
-        _snapName = sh(script: "grep -Po '^name: \\K(.*)' \$(find ${_snapBase} | grep snapcraft.yaml)", returnStdout: true).trim().replaceAll('\n', '')
-    }
-
-    // if not null or empty
-    if(_snapName) {
-        envVars << "SNAP_NAME=${_snapName}"
-    } else {
-        error('Could not determine snap name. Please verify the snapcraft.yaml file and try again.')
-    }
-
-    def cfgFile = []
-
-    if(env.SILO == 'production') {
-        cfgFile = [configFile(fileId: _snapStoreLoginSettings, variable: 'SNAP_STORE_LOGIN')]
-    }
-
-    withEnv(envVars) {
-        configFileProvider(cfgFile) {
-            if(env.SILO == 'production') {
-                sh 'cp $SNAP_STORE_LOGIN $WORKSPACE/edgex-snap-store-login'
-            }
-
-            sh """
-            docker run --rm -u 0:0 --privileged \
-              -v $WORKSPACE:/build \
-              -w /build \
-              -e JOB_TYPE \
-              -e SNAP_REVISION \
-              -e SNAP_CHANNEL \
-              -e SNAP_NAME \
-              ${_snapBuilderImage}
-            """
-        }
-    }
+    sh(script: libraryResource('snap-build.sh'))
 }


### PR DESCRIPTION
Migrate `edgeXSnap` to use new snap-build.sh script provided by Canonical.

Original source script is here: https://github.com/siggiskulason/ci-management/blob/snap-build-snap-script/shell/build-snap.sh.
Migrated to work within edgex-global-pipelines: [resources/snap-build.sh](./resources/snap-build.sh)

Test builds can be found here:
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fedgex-go/detail/PR-2898/9/pipeline/256
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fapp-service-configurable/detail/PR-124/33


Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
