### PR TITLE
feat: inline Snyk docker image scan

### DIFF
--- a/src/test/groovy/edgeXBuildCAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildCAppSpec.groovy
@@ -93,7 +93,8 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     BUILD_DOCKER_IMAGE: true,
                     PUSH_DOCKER_IMAGE: true,
                     SEMVER_BUMP_LEVEL: 'pre',
-                    BUILD_SNAP: false
+                    BUILD_SNAP: false,
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -136,7 +137,8 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     PUSH_DOCKER_IMAGE: true,
                     SEMVER_BUMP_LEVEL: 'patch',
                     BUILD_SNAP: false,
-                    DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"'
+                    DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"',
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildDockerSpec.groovy
+++ b/src/test/groovy/edgeXBuildDockerSpec.groovy
@@ -61,7 +61,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     PUSH_DOCKER_IMAGE: true,
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
-                    SEMVER_BUMP_LEVEL: 'patch'
+                    SEMVER_BUMP_LEVEL: 'patch',
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -77,7 +78,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     DOCKER_CUSTOM_TAGS: 'MyTag1 MyTag2',
                     DOCKER_BUILD_ARGS: 'MyArg1,MyArg2',
-                    SEMVER_BUMP_LEVEL: 'pre'
+                    SEMVER_BUMP_LEVEL: 'pre',
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -92,7 +94,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'pre',
-                    RELEASE_BRANCH_OVERRIDE: 'golang'
+                    RELEASE_BRANCH_OVERRIDE: 'golang',
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -107,7 +110,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'pre',
-                    RELEASE_BRANCH_OVERRIDE: 'golang'
+                    RELEASE_BRANCH_OVERRIDE: 'golang',
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -101,7 +101,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'openapi/v1',
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
-                    SHOULD_BUILD: true
+                    SHOULD_BUILD: true,
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -169,7 +170,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"',
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
-                    SHOULD_BUILD: true
+                    SHOULD_BUILD: true,
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -225,7 +227,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: 'archives/bin',
                     ARTIFACT_TYPES: 'archive',
                     SHOULD_BUILD: true,
-                    ARCHIVE_ARTIFACTS: '**/*.tar.gz **/*.zip'
+                    ARCHIVE_ARTIFACTS: '**/*.tar.gz **/*.zip',
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -279,7 +282,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'openapi/v1',
                     ARTIFACT_ROOT: 'archives/bin',
                     ARTIFACT_TYPES: 'foo',
-                    SHOULD_BUILD: false
+                    SHOULD_BUILD: false,
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -101,7 +101,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     PUBLISH_SWAGGER_DOCS: false,
                     SWAGGER_API_FOLDERS: 'openapi/v1 openapi/v2',
                     // SNAP_CHANNEL: 'latest/edge',
-                    BUILD_SNAP: false
+                    BUILD_SNAP: false,
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -157,6 +158,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'api/v20 api/v30',
                     // SNAP_CHANNEL: 'edge',
                     BUILD_SNAP: false,
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXSnykSpec.groovy
+++ b/src/test/groovy/edgeXSnykSpec.groovy
@@ -4,66 +4,209 @@ import spock.lang.Ignore
 public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
 
     def edgeXSnyk = null
+    def snykImage = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.410.4'
 
     def setup() {
         edgeXSnyk = loadPipelineScriptForTest('vars/edgeXSnyk.groovy')
         explicitlyMockPipelineVariable('out')
+
+        explicitlyMockPipelineVariable('edgex')
+        getPipelineMock('edgex.defaultTrue').call(null) >> true
+        getPipelineMock('edgex.defaultTrue').call(true) >> true
+        getPipelineMock('edgex.defaultFalse').call(null) >> false
+        getPipelineMock('edgex.defaultFalse').call(false) >> false
+        getPipelineMock('edgex.defaultFalse').call(true) >> true
     }
 
     def "Test edgeXSnyk [Should] call snyk monitor without options [When] called with no arguments" () {
         setup:
-            def environmentVariables = [
-                'WORKSPACE': 'MyWorkspace'
-            ]
-            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk()
         then:
-            1 * getPipelineMock('sh').call('snyk monitor --org=edgex-jenkins')
+            1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk monitor --org=edgex-jenkins', returnStatus: true])
     }
 
     def "Test edgeXSnyk [Should] call snyk monitor without options [When] called with no arguments when SNYK_ORG" () {
         setup:
             def environmentVariables = [
-                'WORKSPACE': 'MyWorkspace',
                 'SNYK_ORG': 'MySnykOrg'
             ]
             edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXSnyk()
         then:
-            1 * getPipelineMock('sh').call('snyk monitor --org=MySnykOrg')
+            1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk monitor --org=MySnykOrg', returnStatus: true])
     }
 
-    def "Test edgeXSnyk [Should] call snyk monitor with docker options [When] called with dockerImage and dockerFile arguments" () {
-        setup:
-            def environmentVariables = [
-                'WORKSPACE': 'MyWorkspace'
-            ]
-            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
-        when:
-            edgeXSnyk('MyDockerImage', 'MyDockerFile')
-        then:
-            1 * getPipelineMock('sh').call('snyk monitor --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile')
-    }
+    // Docker image tests
 
     def "Test edgeXSnyk [Should] provide the expected arguments to the snyk docker image [When] called" () {
         setup:
-            def environmentVariables = [
-                'WORKSPACE': 'MyWorkspace'
-            ]
-            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.317.0') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
-            edgeXSnyk('MyDockerImage', 'MyDockerFile')
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile')
         then:
             1 * getPipelineMock('DockerImageMock.inside').call(_) >> { _arguments ->
-                def dockerArgs = "-u 0:0 --privileged -v /var/run/docker.sock:/var/run/docker.sock -v MyWorkspace:/ws -w /ws --entrypoint=''"
+                def dockerArgs = "-u 0:0 --privileged -v /var/run/docker.sock:/var/run/docker.sock --entrypoint=''"
                 assert dockerArgs == _arguments[0][0]
             }
-    }    
+    }
+
+    def "Test edgeXSnyk [Should] call snyk test with docker options [When] called with dockerImage and dockerFile arguments and no severity threshold" () {
+        setup:
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile')
+        then:
+            1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk test --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile --policy-path=./.snyk | tee snykResults.log', returnStatus: true])
+            1 * getPipelineMock("sh").call("set -o pipefail ; curl -s 'https://raw.githubusercontent.com/edgexfoundry/security-pipeline-policies/main/snyk/.snyk' | tee .snyk")
+    }
+
+    def "Test edgeXSnyk [Should] call snyk test with docker options [When] called with dockerImage and dockerFile arguments and high severity threshold" () {
+        setup:
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile', severity: 'high')
+        then:
+            1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk test --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile --severity-threshold=high --policy-path=./.snyk | tee snykResults.log', returnStatus: true])
+            1 * getPipelineMock("sh").call("set -o pipefail ; curl -s 'https://raw.githubusercontent.com/edgexfoundry/security-pipeline-policies/main/snyk/.snyk' | tee .snyk")
+    }
+
+    def "Test edgeXSnyk [Should] call snyk test with docker options and send email [When] called with dockerImage and dockerFile arguments" () {
+        setup:
+            def environmentVariables = [
+                'PROJECT': 'mock',
+                'JOB_NAME': 'MyMockJob',
+                'BUILD_URL': 'MockBuildUrl/'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+
+            // exit code 1
+            // simulate scan returning potential vulnerable results
+            getPipelineMock('sh')([
+                returnStatus: true,
+                script: 'set -o pipefail ; snyk test --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile --policy-path=./.snyk | tee snykResults.log'
+            ]) >> {
+                1
+            }
+            getPipelineMock('readFile').call(file: './snykResults.log') >> 'MockSnykLog'
+
+            def messageBody = '''Possible vulnerablities have been found by Snyk in for the following build: MyMockJob
+More details can be found here:
+===============================================
+Build URL: MockBuildUrl/
+Build Console: MockBuildUrl/console
+
+Snyk Log:
+MockSnykLog
+'''
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile', emailTo: 'mock-user@example.com')
+        then:
+            1 * getPipelineMock("string.call").call(['credentialsId':'snyk-cli-token', 'variable':'SNYK_TOKEN'])
+            1 * getPipelineMock("mail").call([body: messageBody, subject: '[Snyk] Possible vulnerabilities discovered in [mock] scan', to: 'mock-user@example.com'])
+    }
+
+    def "Test edgeXSnyk [Should] call snyk test with docker options and not send email [When] called with dockerImage and dockerFile arguments" () {
+        setup:
+            def environmentVariables = [
+                'JOB_BASE_NAME': 'MyMockJob',
+                'BUILD_URL': 'MockBuildUrl/'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+
+            // exit code 1
+            // simulate scan returning potential vulnerable results
+            getPipelineMock('sh')([
+                returnStatus: true,
+                script: 'set -o pipefail ; snyk test --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile --policy-path=./.snyk | tee snykResults.log'
+            ]) >> {
+                1
+            }
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile', emailTo: 'mock-user@example.com', sendEmail: false)
+        then:
+            0 * getPipelineMock("mail").call()
+    }
+
+    def "Test edgeXSnyk [Should] call snyk test with docker options and error [When] called with dockerImage and dockerFile arguments" () {
+        setup:
+            def environmentVariables = [
+                'JOB_BASE_NAME': 'MyMockJob',
+                'BUILD_URL': 'MockBuildUrl/'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+
+            // exit code 2
+            // simulate scan error
+            getPipelineMock('sh')([
+                returnStatus: true,
+                script: 'set -o pipefail ; snyk test --org=edgex-jenkins --docker MyDockerImage --file=./MyDockerFile --policy-path=./.snyk | tee snykResults.log'
+            ]) >> {
+                2
+            }
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile', emailTo: 'mock-user@example.com', sendEmail: false)
+        then:
+            1 * getPipelineMock('error').call('[edgeXSnyk] An error occurred during the snyk scan see console output for details.')
+    }
+
+    def "Test edgeXSnyk [Should] call snyk test with docker options and send HTML email [When] called with dockerImage and dockerFile arguments" () {
+        setup:
+            def environmentVariables = [
+                'PROJECT': 'mock',
+                'SNYK_ORG': 'MockOrg'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+
+            // exit code 1
+            // simulate scan returning potential vulnerable results
+            getPipelineMock('sh')([
+                returnStatus: true,
+                script: 'set -o pipefail ; snyk test --org=MockOrg --docker MyDockerImage --file=./MyDockerFile --policy-path=./.snyk --json | snyk-to-html -o snykReport.html'
+            ]) >> {
+                1
+            }
+            getPipelineMock('readFile').call(file: './snykReport.html') >> 'MockHTML'
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile', emailTo: 'mock-user@example.com', htmlReport: true)
+        then:
+            1 * getPipelineMock("string.call").call(['credentialsId':'snyk-cli-token', 'variable':'SNYK_TOKEN'])
+            1 * getPipelineMock("sh").call('rm -f snykReport.html')
+            1 * getPipelineMock("mail").call([body: 'MockHTML', subject: '[Snyk] Possible vulnerabilities discovered in [mock] scan', to: 'mock-user@example.com', mimeType: 'text/html'])
+    }
+
+    def "Test edgeXSnyk [Should] download global snyk ignore policy [When] called with test" () {
+        setup:
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile')
+        then:
+            1 * getPipelineMock("sh").call("set -o pipefail ; curl -s 'https://raw.githubusercontent.com/edgexfoundry/security-pipeline-policies/main/snyk/.snyk' | tee .snyk")
+    }
+
+    def "Test edgeXSnyk [Should] download custom snyk ignore policy [When] called with test" () {
+        setup:
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk(command: 'test', dockerImage: 'MyDockerImage', dockerFile: 'MyDockerFile', ignorePolicy: 'https://mock.com/.synk')
+        then:
+            1 * getPipelineMock("sh").call("set -o pipefail ; curl -s 'https://mock.com/.synk' | tee .snyk")
+    }
+
+    def "Test edgeXSnyk [Should] not download global snyk ignore policy [When] called with monitor" () {
+        setup:
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk(command: 'monitor')
+        then:
+            0 * getPipelineMock("sh").call("set -o pipefail ; curl -s 'https://raw.githubusercontent.com/edgexfoundry/security-pipeline-policies/main/snyk/.snyk' | tee .snyk")
+    }
 
 }


### PR DESCRIPTION
This PR modifies `edgeXSnyk.groovy` to allow on-demand testing of images that are pushed to a docker registry.

edgeXSnyk should:

- implement on-demand testing of docker images (pushed to nexus)
- notify distribution list of users when vulnerabilities are found
- allow ignoring of Snyk findings via the `.snyk` policy

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

See jobs under this PR:
`edgeXBuildGoApp`
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/view/change-requests/job/PR-77/

`edgeXBuildGoAppParallel`
https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional-Testing/job/eojeda-edgex-go-snyk/4/console

Example HTML Email:
![image](https://user-images.githubusercontent.com/1890273/98006116-1bee0c80-1daf-11eb-80d5-300828d63c62.png)

Example Plain Text Email:
![image](https://user-images.githubusercontent.com/1890273/98006132-201a2a00-1daf-11eb-9581-ebf1218e45e9.png)

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
