### PR TITLE
refactor: docker login in all prep stages

### DIFF
--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -81,6 +81,9 @@ def call(config) {
                 steps {
                     script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
+                    // docker login for the to make sure all docker commands are authenticated
+                    // in this specific node
+                    edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                 }
             }
 
@@ -111,7 +114,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
-                                        // should this be in it's own stage?
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }
@@ -198,7 +203,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
-                                        // should this be in it's own stage?
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -82,6 +82,9 @@ def call(config) {
                 steps {
                     script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
+                    // docker login for the to make sure all docker commands are authenticated
+                    // in this specific node
+                    edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                 }
             }
 
@@ -107,6 +110,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }
@@ -132,7 +138,6 @@ def call(config) {
 
                                 steps {
                                     script {
-                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         taggedAMD64Images = edgeXDocker.push("${DOCKER_IMAGE_NAME}", env.DOCKER_PUSH_LATEST == 'true', "${DOCKER_NEXUS_REPO}")
                                     }
                                 }
@@ -170,6 +175,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }
@@ -195,7 +203,6 @@ def call(config) {
 
                                 steps {
                                     script {
-                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         taggedARM64Images = edgeXDocker.push("${DOCKER_IMAGE_NAME}-${ARCH}", env.DOCKER_PUSH_LATEST == 'true', "${DOCKER_NEXUS_REPO}")
                                     }
                                 }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -84,6 +84,9 @@ def call(config) {
                 steps {
                     script { edgex.releaseInfo() }
                     edgeXSetupEnvironment(_envVarMap)
+                    // docker login for the to make sure all docker commands are authenticated
+                    // in this specific node
+                    edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                 }
             }
 
@@ -138,7 +141,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
-                                        // should this be in it's own stage?
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }
@@ -228,7 +233,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
-                                        // should this be in it's own stage?
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -52,6 +52,9 @@ def call(config) {
                     script {
                         edgex.releaseInfo()
                         edgeXSetupEnvironment(_envVarMap)
+                        // docker login for the to make sure all docker commands are authenticated
+                        // in this specific node
+                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
 
                         // Generate list docker images to build
                         dockerImagesToBuild = getDockersFromFilesystem(env.DOCKER_FILE_GLOB, env.DOCKER_IMAGE_NAME_PREFIX, env.DOCKER_IMAGE_NAME_SUFFIX)
@@ -172,7 +175,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
-                                        // should this be in it's own stage?
+                                        // docker login for the to make sure all docker commands are authenticated
+                                        // in this specific node
+                                        edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
                                         }


### PR DESCRIPTION
Currently any `docker pull` commands issued by the pipelines are anonymous due to no docker login commands being issues until the docker push stage. Due to new rate limits being imposed by docker for `docker pull` commands, we now should be doing authenticated requests. This PR adds the `docker login` to the beginning of each prep stage when nodes are spun up to make sure requests are authenticated.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/Functional-Testing%2Feojeda-edgex-go-experimental/detail/eojeda-edgex-go-experimental/6/pipeline

https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/Functional-Testing%2Feojeda-sample-service-test/detail/eojeda-sample-service-test/3/pipeline

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
