### PR TITLE
fix: add function to enable docker registry mirror

### DIFF
--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -120,6 +120,7 @@ def call(config) {
                                     script {
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
+                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         if(env.USE_SEMVER == 'true') {
                                             unstash 'semver'
@@ -207,6 +208,7 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -487,4 +489,11 @@ def toEnvironment(config) {
     edgex.printMap envMap
 
     envMap
+}
+
+// Temp fix while LF updates base packer images
+def enableDockerProxy(proxyHost, debug = false) {
+    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
+    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
+    sh 'sudo service docker restart | true'
 }

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -110,6 +110,7 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -175,6 +176,7 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -394,4 +396,11 @@ def toEnvironment(config) {
     edgex.printMap envMap
 
     envMap
+}
+
+// Temp fix while LF updates base packer images
+def enableDockerProxy(proxyHost, debug = false) {
+    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
+    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
+    sh 'sudo service docker restart | true'
 }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -141,6 +141,7 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -233,6 +234,7 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -645,4 +647,11 @@ def toEnvironment(config) {
     edgex.printMap envMap
 
     envMap
+}
+
+// Temp fix while LF updates base packer images
+def enableDockerProxy(proxyHost, debug = false) {
+    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
+    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
+    sh 'sudo service docker restart | true'
 }


### PR DESCRIPTION
This is a temporary function I added to all the pipelines to enable the Nexus registry mirror on the fly while the LF updates the packer images.

Testing with this build: https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fsample-service/detail/PR-83/1/

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
