### PR TITLE
feat: go modules no longer bump patch semver

### DIFF
--- a/src/test/groovy/edgeXBuildGoModSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoModSpec.groovy
@@ -21,8 +21,7 @@ public class EdgeXBuildGoModSpec extends JenkinsPipelineSpecification {
                 project:'go-mod-bootstrap',
                 goVersion:'1.11',
                 buildImage:false,
-                pushImage:false,
-                semverBump:'patch'])
+                pushImage:false])
     }
 
 }

--- a/vars/edgeXBuildGoMod.groovy
+++ b/vars/edgeXBuildGoMod.groovy
@@ -15,10 +15,10 @@
 //
 
 def call(config = [:]) {
+    // per DevOps WG meeting on 12/3/20 go mod does not bump the patch version anymore
     def goModDefaults = [
         buildImage: false,
-        pushImage: false,
-        semverBump: 'patch'
+        pushImage: false
     ]
 
     config << goModDefaults


### PR DESCRIPTION
Per the DevOps WG meeting on 12/3/20, we are changing the way go modules are versioned to match the other Go projects. (So bumping pre-release version of the `semver 1.x.x-dev.x`)

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
