### PR TITLE
feat: allow Snyk docker scans to be disabled via config

### DIFF
--- a/src/test/groovy/edgeXBuildCAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildCAppSpec.groovy
@@ -94,7 +94,8 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     PUSH_DOCKER_IMAGE: true,
                     SEMVER_BUMP_LEVEL: 'pre',
                     BUILD_SNAP: false,
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }
@@ -138,7 +139,8 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     SEMVER_BUMP_LEVEL: 'patch',
                     BUILD_SNAP: false,
                     DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"',
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildDockerSpec.groovy
+++ b/src/test/groovy/edgeXBuildDockerSpec.groovy
@@ -62,7 +62,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'patch',
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -79,7 +80,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     DOCKER_CUSTOM_TAGS: 'MyTag1 MyTag2',
                     DOCKER_BUILD_ARGS: 'MyArg1,MyArg2',
                     SEMVER_BUMP_LEVEL: 'pre',
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -95,7 +97,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'pre',
                     RELEASE_BRANCH_OVERRIDE: 'golang',
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -111,7 +114,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'pre',
                     RELEASE_BRANCH_OVERRIDE: 'golang',
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -102,7 +102,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
                     SHOULD_BUILD: true,
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }
@@ -171,7 +172,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
                     SHOULD_BUILD: true,
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }
@@ -228,7 +230,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_TYPES: 'archive',
                     SHOULD_BUILD: true,
                     ARCHIVE_ARTIFACTS: '**/*.tar.gz **/*.zip',
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }
@@ -283,7 +286,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: 'archives/bin',
                     ARTIFACT_TYPES: 'foo',
                     SHOULD_BUILD: false,
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -102,7 +102,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'openapi/v1 openapi/v2',
                     // SNAP_CHANNEL: 'latest/edge',
                     BUILD_SNAP: false,
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }
@@ -158,7 +159,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'api/v20 api/v30',
                     // SNAP_CHANNEL: 'edge',
                     BUILD_SNAP: false,
-                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org'
+                    SECURITY_NOTIFY_LIST: 'security-issues@lists.edgexfoundry.org',
+                    SNYK_DOCKER_SCAN: false
                 ]
             ]
     }

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -310,6 +310,7 @@ def call(config) {
                     allOf {
                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
+                        environment name: 'SNYK_DOCKER_SCAN', value: 'true'
                         expression { edgex.isReleaseStream() }
                     }
                 }
@@ -468,6 +469,8 @@ def toEnvironment(config) {
         _pushImage = false
     }
 
+    def _snykDockerScan = edgex.defaultFalse(config.snykDockerScan)
+
     def envMap = [
         MAVEN_SETTINGS: _mavenSettings,
         PROJECT: _projectName,
@@ -486,7 +489,8 @@ def toEnvironment(config) {
         SEMVER_BUMP_LEVEL: _semverBump,
         //SNAP_CHANNEL: _snapChannel,
         BUILD_SNAP: _buildSnap,
-        SECURITY_NOTIFY_LIST: _securityNotify
+        SECURITY_NOTIFY_LIST: _securityNotify,
+        SNYK_DOCKER_SCAN: _snykDockerScan
     ]
 
     // encode with comma in case build arg has space

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -234,6 +234,7 @@ def call(config) {
                 when { 
                     allOf {
                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
+                        environment name: 'SNYK_DOCKER_SCAN', value: 'true'
                         expression { edgex.isReleaseStream() || (env.GIT_BRANCH == env.RELEASE_BRANCH_OVERRIDE) }
                     }
                 }
@@ -361,6 +362,7 @@ def toEnvironment(config) {
     def _semverBump            = config.semverBump ?: 'pre'
     def _releaseBranchOverride = config.releaseBranchOverride
     def _securityNotify        = 'security-issues@lists.edgexfoundry.org'
+    def _snykDockerScan        = edgex.defaultFalse(config.snykDockerScan)
 
     def envMap = [
         MAVEN_SETTINGS: _mavenSettings,
@@ -376,7 +378,8 @@ def toEnvironment(config) {
         ARCHIVE_IMAGE: _archiveImage,
         ARCHIVE_NAME: _archiveName,
         SEMVER_BUMP_LEVEL: _semverBump,
-        SECURITY_NOTIFY_LIST: _securityNotify
+        SECURITY_NOTIFY_LIST: _securityNotify,
+        SNYK_DOCKER_SCAN: _snykDockerScan
     ]
 
     if(_releaseBranchOverride) {

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -352,6 +352,7 @@ def call(config) {
                     allOf {
                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
+                        environment name: 'SNYK_DOCKER_SCAN', value: 'true'
                         expression { edgex.isReleaseStream() }
                     }
                 }
@@ -611,6 +612,8 @@ def toEnvironment(config) {
         _pushImage = false
     }
 
+    def _snykDockerScan = edgex.defaultFalse(config.snykDockerScan)
+
     def envMap = [
         MAVEN_SETTINGS: _mavenSettings,
         PROJECT: _projectName,
@@ -638,7 +641,8 @@ def toEnvironment(config) {
         ARTIFACT_ROOT: _artifactRoot,
         ARTIFACT_TYPES: _artifactTypes.join(' '),
         SHOULD_BUILD: _shouldBuild,
-        SECURITY_NOTIFY_LIST: _securityNotify
+        SECURITY_NOTIFY_LIST: _securityNotify,
+        SNYK_DOCKER_SCAN: _snykDockerScan
     ]
 
     // encode with comma in case build arg has space

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -328,6 +328,7 @@ def call(config) {
                     allOf {
                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
+                        environment name: 'SNYK_DOCKER_SCAN', value: 'true'
                         expression { edgex.isReleaseStream() }
                     }
                 }
@@ -505,6 +506,7 @@ def toEnvironment(config) {
 
     // def _snapChannel           = config.snapChannel ?: 'latest/edge'
     def _buildSnap             = edgex.defaultFalse(config.buildSnap)
+    def _snykDockerScan        = edgex.defaultFalse(config.snykDockerScan)
 
     // no image to build, no image to push
     if(!_buildImage) {
@@ -534,7 +536,8 @@ def toEnvironment(config) {
         SWAGGER_API_FOLDERS: _swaggerApiFolders.join(' '),
         // SNAP_CHANNEL: _snapChannel,
         BUILD_SNAP: _buildSnap,
-        SECURITY_NOTIFY_LIST: _securityNotify
+        SECURITY_NOTIFY_LIST: _securityNotify,
+        SNYK_DOCKER_SCAN: _snykDockerScan
     ]
 
     edgex.bannerMessage "[edgeXBuildGoParallel] Pipeline Parameters:"


### PR DESCRIPTION
We are running into Snyk limits so I am disabling the docker scans until we closer to the Ireland release. Then they can be enabled globally or on specific repositories.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
