### PR TITLE
Implement ability to release an EdgeX code repo from a specific commit

### DIFF
--- a/src/test/groovy/edgeXReleaseGitTagUtilSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagUtilSpec.groovy
@@ -18,6 +18,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
             'name': 'sample-service',
             'version': '1.2.3',
             'releaseStream': 'master',
+            'commitId': 'f33f986d90bbf8c9cd5dc4c341daab837968a04e',
             'repo': 'https://github.com/edgexfoundry/sample-service.git'
         ]
     }
@@ -52,6 +53,14 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
             edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'repo'})
         then:
             1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'repo\'')
+    }
+
+    def "Test validate [Should] raise error [When] release info yaml does not have a commitId attribute" () {
+        setup:
+        when:
+            edgeXReleaseGitTagUtil.validate(validReleaseInfo.findAll {it.key != 'commitId'})
+        then:
+            1 * getPipelineMock('error').call('[edgeXReleaseGitTag]: Release yaml does not contain \'commitId\'')
     }
 
     def "Test getSSHRepoName [Should] return expected #expectedResult [When] called" () {
@@ -112,7 +121,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
         when:
             edgeXReleaseGitTagUtil.releaseGitTag(validReleaseInfo, 'MyCredentials')
         then:
-            1 * getPipelineMock('edgeXReleaseGitTag.cloneRepo').call('https://github.com/edgexfoundry/sample-service.git', 'master', 'sample-service', 'MyCredentials')
+            1 * getPipelineMock('edgeXReleaseGitTag.cloneRepo').call('https://github.com/edgexfoundry/sample-service.git', 'master', 'sample-service', 'f33f986d90bbf8c9cd5dc4c341daab837968a04e', 'MyCredentials')
             1 * getPipelineMock('withEnv').call(_) >> { _arguments ->
                     assert _arguments[0][0][0] == 'SEMVER_BRANCH=master'
                 }

--- a/src/test/groovy/edgeXReleaseSpec.groovy
+++ b/src/test/groovy/edgeXReleaseSpec.groovy
@@ -440,6 +440,7 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
                     version:'v1.2.0', 
                     releaseName:'geneva', 
                     releaseStream:'master',
+                    commitId:'0123456789',
                     repo:'https://github.com/edgexfoundry/app-functions-sdk-go.git', 
                     gitTag:false,
                     gitTagDestination:'https://github.com/edgexfoundry/app-functions-sdk-go.git', 
@@ -456,7 +457,6 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
             0 * getPipelineMock("build").call(_)
     }
 
-
     def "Test stageArtifact [Should] call expected [When] DRY_RUN is false" () {
         setup:
             getPipelineMock('edgex.isDryRun').call() >> false
@@ -466,6 +466,7 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
                     version:'v1.2.0', 
                     releaseName:'geneva', 
                     releaseStream:'master',
+                    commitId:'0123456789',
                     repo:'https://github.com/edgexfoundry/app-functions-sdk-go.git', 
                     gitTag:false,
                     gitTagDestination:'https://github.com/edgexfoundry/app-functions-sdk-go.git', 
@@ -479,7 +480,7 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
         when:
             edgeXRelease.stageArtifact(step)
         then:
-            1 * getPipelineMock("build").call(["job":"../app-functions-sdk-go/master","propagate":true, "wait":true])
+            1 * getPipelineMock("build").call(["job": "../app-functions-sdk-go/master", "parameters": [[$class: 'StringParameterValue', name: 'CommitId', value: '0123456789']], "propagate": true, "wait": true])
     }
 
 }

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -79,7 +79,12 @@ def call(config) {
         triggers {
             issueCommentTrigger('.*^recheck$.*')
         }
-
+        parameters {
+            string(
+                name: 'CommitId',
+                defaultValue: '',
+                description: 'The commitId in the code repository from where to initiate the build - should be used only if building via edgeXRelease')
+        }
         stages {
             stage('Prepare') {
                 steps {
@@ -122,6 +127,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
@@ -214,6 +222,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -76,7 +76,12 @@ def call(config) {
         triggers {
             issueCommentTrigger('.*^recheck$.*')
         }
-
+        parameters {
+            string(
+                name: 'CommitId',
+                defaultValue: '',
+                description: 'The commitId in the code repository from where to initiate the build - should be used only if building via edgeXRelease')
+        }
         stages {
             stage('Prepare') {
                 steps {
@@ -110,6 +115,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
@@ -176,6 +184,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -79,6 +79,12 @@ def call(config) {
         triggers {
             issueCommentTrigger('.*^recheck$.*')
         }
+        parameters {
+            string(
+                name: 'CommitId',
+                defaultValue: '',
+                description: 'The commitId in the code repository from where to initiate the build - should be used only if building via edgeXRelease')
+        }
         stages {
             stage('Prepare') {
                 steps {
@@ -145,6 +151,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
@@ -240,6 +249,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -82,7 +82,12 @@ def call(config) {
         triggers {
             issueCommentTrigger('.*^recheck$.*')
         }
-
+        parameters {
+            string(
+                name: 'CommitId',
+                defaultValue: '',
+                description: 'The commitId in the code repository from where to initiate the build - should be used only if building via edgeXRelease')
+        }
         stages {
             stage('Prepare') {
                 steps {
@@ -123,6 +128,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // builds ci-base-image used to cache dependencies and system libs
                                         prepBaseBuildImage()
@@ -215,6 +223,9 @@ def call(config) {
                             stage('Prep') {
                                 steps {
                                     script {
+                                        if(params.CommitId) {
+                                            sh "git checkout ${params.CommitId}"
+                                        }
                                         enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node

--- a/vars/edgeXRelease.groovy
+++ b/vars/edgeXRelease.groovy
@@ -38,13 +38,13 @@ def parallelStepFactoryTransform(step) {
         stage(step.name.toString()) {
             if(step.gitTag == true) {
                 stage("Git Tag Publish") {
-                    edgeXReleaseGitTag(step, [credentials:"edgex-jenkins-ssh", bump:false, tag:true])
+                    edgeXReleaseGitTag(step, [credentials: "edgex-jenkins-ssh", bump: false, tag: true])
                 }
                 stage("Stage Artifact") {
                     stageArtifact(step)
                 }
                 stage("Bump Semver") {
-                    edgeXReleaseGitTag(step, [credentials:"edgex-jenkins-ssh", bump:true, tag:false])
+                    edgeXReleaseGitTag(step, [credentials: "edgex-jenkins-ssh", bump: true, tag: false])
                 }
             }
             
@@ -67,8 +67,13 @@ def stageArtifact(step) {
     rebuildRepo = step.repo.split('/')[-1].split('.git')[0]
     println "[edgeXRelease]: building/staging for ${rebuildRepo} - DRY_RUN: ${env.DRY_RUN}"
     if(edgex.isDryRun()) {
-        println("build job: '../${rebuildRepo}/${step.releaseStream}, propagate: true, wait: true)")
-    }else{
-        build(job: '../'+rebuildRepo+'/'+step.releaseStream, propagate: true, wait: true)
+        println("build job: '../${rebuildRepo}/${step.releaseStream}, parameters: [CommitId: ${step.commitId}], propagate: true, wait: true)")
+    }
+    else {
+        build(
+            job: '../' + rebuildRepo + '/' + step.releaseStream,
+            parameters: [[$class: 'StringParameterValue', name: 'CommitId', value: step.commitId]],
+            propagate: true,
+            wait: true)
     }
 }

--- a/vars/edgeXReleaseGitTagUtil.groovy
+++ b/vars/edgeXReleaseGitTagUtil.groovy
@@ -22,6 +22,7 @@ releaseYaml:
 name: 'sample-service'
 version: '1.1.2'
 releaseStream: 'master'
+commitId: '0cc1d67607642c9413e4a80d25a2df35ecc76d41'
 repo: 'https://github.com/edgexfoundry/sample-service.git'
 gitTag: true
 semverBumpLevel: 'patch'  # optional and defaults to '-pre=dev pre'
@@ -43,6 +44,9 @@ def validate(releaseInfo) {
     }
     if(!releaseInfo.repo) {
         error("[edgeXReleaseGitTag]: Release yaml does not contain 'repo'")
+    }
+    if(!releaseInfo.commitId) {
+        error("[edgeXReleaseGitTag]: Release yaml does not contain 'commitId'")
     }
 }
 
@@ -67,7 +71,7 @@ def signGitTag(version, name) {
 def releaseGitTag(releaseInfo, credentials, bump = true, tag = true) {
     // exception handled function that clones, sets and signs git tag version
     try {
-        edgeXReleaseGitTag.cloneRepo(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name, credentials)
+        edgeXReleaseGitTag.cloneRepo(releaseInfo.repo, releaseInfo.releaseStream, releaseInfo.name, releaseInfo.commitId, credentials)
         withEnv(["SEMVER_BRANCH=${releaseInfo.releaseStream}"]) {
             if (tag){
                 edgeXReleaseGitTag.setAndSignGitTag(releaseInfo.name, releaseInfo.version)


### PR DESCRIPTION
Update edgeXrelease* functions to facilitate releasing edgeX repos from a specific commit Id.

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
Fixes 
https://github.com/edgexfoundry/cd-management/issues/110

## Sandbox Testing
Test edgeXReleaseGitTag
https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional-Testing/job/test-edgeXReleaseGitTag/6/
Test edgeXRelease
https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional-Testing/job/test-edgeXRelease/4/
Unable to test edgeXRelease end-to-end since build command is passed in a relative path for the build to execute which doesn't exist in Sandbox, and would be difficult to emulate. Thus will rely on testing edgeXRelease and build using PR to cd-management on edgex-global-pipelines@experimental.

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
After this is merged, I will continue functional testing of edgeXRelease by creating a PR to release branch in cd-management to release sample-service at a specific commit Id.
