### PR TITLE
feat: Add ability to send HTML emails on build failure

### DIFF
--- a/resources/build-log-extract.sh
+++ b/resources/build-log-extract.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# jenkins will provide these
+# JENKINS_URL=https://jenkins.edgexfoundry.org
+# BUILD_NUMBER=13
+# JOB_NAME=edgexfoundry/sample-service/PR-93
+
+#remove trailing slash
+JENKINS_URL_CLEAN=${JENKINS_URL%/}
+
+#build component of build rest url
+url_base=${JENKINS_URL_CLEAN}/blue/rest/organizations/jenkins/pipelines
+
+slashes="${JOB_NAME//[^\/]}"
+num_slashes="${#slashes}"
+
+if [ $num_slashes -eq 1 ]; then
+    org_name=$(echo $JOB_NAME | cut -d'/' -f1)
+    project_name=$(echo $JOB_NAME | cut -d'/' -f2)
+
+    node_url="$url_base/$org_name/pipelines/$project_name/runs/$BUILD_NUMBER/nodes/?limit=10000"
+
+elif [ $num_slashes -eq 2 ]; then
+    org_name=$(echo $JOB_NAME | cut -d'/' -f1)
+    project_name=$(echo $JOB_NAME | cut -d'/' -f2)
+    project_branch=$(echo $JOB_NAME | cut -d'/' -f3)
+
+    node_url="$url_base/$org_name/pipelines/$project_name/branches/$project_branch/runs/$BUILD_NUMBER/nodes/?limit=10000"
+else
+    node_url="$url_base/$JOB_NAME/pipelines/runs/$BUILD_NUMBER/nodes/?limit=10000"
+fi
+
+node_json=$(curl -s "$node_url")
+
+failed=$(echo "$node_json" | jq -r '.[] | select(.result == "FAILURE") | .id')
+# echo "[debug] Found Failed Nodes:" ; echo "$failed"
+
+# this build will return:
+# <last failed stage name>
+# ^^^^^^^^^^^^
+# <log>
+
+if [ "$failed" != "" ]; then
+    # the last failed node should be one we are looking for
+    id=$(echo "$failed" | tail -n 1)
+
+    failedNode=$(echo "$node_json" | jq ".[] | select(.id == \"$id\")")
+    nodeName=$(echo "$failedNode" | jq -r ".displayName")
+    stepsHref=$(echo "$failedNode" | jq -r "._links.steps.href")
+    steps_json=$(curl -s "${JENKINS_URL_CLEAN}${stepsHref}")
+    failed_steps=$(echo "$steps_json" | jq -r '.[] | select(.result == "FAILURE") | .id')
+    # echo "[debug] Found Failed Steps:" ; echo "$failed_steps"
+
+    # only pull log for last failed step
+    if [ "$failed_steps" != "" ]; then
+        failed_step_id=$(echo $failed_steps | tail -n 1)
+        last_failed=$(echo "$steps_json" | jq -r ".[] | select(.id == \"$failed_step_id\")")
+        logHref=$(echo "$last_failed" | jq -r ".actions[] | select(.urlName == \"log\")._links.self.href")
+        if [ "$logHref" != "" ]; then
+            # output format
+            echo "$nodeName"
+            echo "^^^^^^^^^^^^"
+            curl -s "${JENKINS_URL_CLEAN}$logHref"
+        fi
+    fi
+fi

--- a/resources/email/build-notification-template.html
+++ b/resources/email/build-notification-template.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Varela|Varela+Round" /> 
+    <link rel="stylesheet" href="https://use.typekit.net/vks2ysr.css" />
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<style type="text/css">
+    body, td, div { font-family: Varela, sans-serif }
+    body { background-color: #ccc;margin: 10px 0px; }
+</style>
+<body>
+    <table border="0" width="50%" style="margin:auto;padding:30px;background-color: #F3F3F3;border:1px solid #2d2848;">
+        <tr>
+            <td>
+                <table border="0" width="100%">
+                    <tr>
+                        <td style="text-align: center;">
+                            <h1><img src="https://wiki.edgexfoundry.org/download/attachments/25297046/logo_edgex_foundry_4x.png?version=1&modificationDate=1549409434000&api=v2" style="height: 40px;" alt="EdgeXFoundry Logo" /></h1>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <table border="0" cellpadding="0" cellspacing="0" style="width:100%;background-color: #fff;">
+                    <tr>
+                        <td style="text-align:center; background-color:#2d2848;height:70px;font-size:30px;color:#fff;"><i class="fa fa-cogs" style="padding-right: 10px;" aria-hidden="true"></i> Jenkins Build Notification</td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: center;">
+                            <div style="display: inline-block;margin:10px 0px 30px 0px;border-radius:4px;padding:10px 20px;border: 0;color:#fff;background-color:#425cc6;"><a style="color: #fff; text-decoration: none;" target="_blank" href="{{ buildConsoleUrl }}"><i class="fa fa-terminal" aria-hidden="true"></i> Build Console</a></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 10px;">
+                            <table border="0" width="100%">
+                                <tr>
+                                    <td style="background-color:{{color}}; margin: 10px;color:#fff; text-align: left; padding: 5px 0 5px 10px"><i class="fa fa-exclamation-circle" aria-hidden="true"></i> Build {{ status }}</td>
+                                </tr>
+                                <tr>
+                                    <table border="0" width="100%" style="font-size: 12px">
+                                        <tr>
+                                            <td style="width: 150px; font-weight: bold;">Job Name</td>
+                                            <td><i class="fa fa-chevron-right" style="padding-right: 10px;" aria-hidden="true"></i> {{ jobName }}</td>
+                                            <td style="width: 100px; font-weight: bold;">Duration</td>
+                                            <td><i class="fa fa-clock-o" style="padding-right: 10px;" aria-hidden="true"></i> {{ duration }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td style="width: 150px; font-weight: bold;">Author</td>
+                                            <td><i class="fa fa-user" style="padding-right: 10px;" aria-hidden="true"></i> {{ author }}</td>
+                                            <td style="width: 100px; font-weight: bold;">Branch</td>
+                                            <td><i class="fa fa-clone" style="padding-right: 10px;" aria-hidden="true"></i> {{ branch }}</td>
+                                        </tr>
+                                        <tr>
+                                            <td style="width: 150px; font-weight: bold; vertical-align: top">Change Log</td>
+                                            <td colspan="3">
+                                                {{#changeLog}}
+                                                <div style="padding: 5px 0;"><i class="fa fa-file" style="padding-right: 10px;" aria-hidden="true"></i> {{.}}</div>
+                                                {{/changeLog}}
+                                            </td>
+                                        </tr>
+                                        {{#buildUrl}}
+                                        <tr>
+                                            <td style="width: 150px; font-weight: bold;">Build URL</td>
+                                            <td colspan="3"><i class="fa fa-globe" style="padding-right: 10px;" aria-hidden="true"></i> <a href="{{ buildUrl }}">{{ buildUrl }}</a></td>
+                                        </tr>
+                                        {{/buildUrl}}
+                                        {{#gitUrl}}
+                                        <tr>
+                                            <td style="width: 150px; font-weight: bold;">GitHub URL</td>
+                                            <td colspan="3"><i class="fa fa-github-square" style="padding-right: 10px;" aria-hidden="true"></i> <a href="{{ gitUrl }}">{{ gitUrl }}</a></td>
+                                        </tr>
+                                        {{/gitUrl}}
+                                        {{#failedStage}}
+                                        <tr>
+                                            <td style="width: 150px; font-weight: bold;" style="height: 50px; vertical-align: bottom;">Failed Stage</td>
+                                            <td style="vertical-align: bottom;">{{ failedStage }}</td>
+                                        </tr>
+                                        {{/failedStage}}
+                                        {{#buildLog}}
+                                        <tr>
+                                            <td colspan="4"><div style="background: #ddd; padding: 0 10px; height: 300px; overflow: auto;"><pre style="font-family: 'Source Code Pro', Courier New, monospace; font-size: 12px;">{{ buildLog }}</pre></div>
+                                            </td>
+                                        </tr>
+                                        {{/buildLog}}
+                                    </table>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align: center;">
+                            <div style="display: inline-block;margin:10px 0px 30px 0px;border-radius:4px;padding:10px 20px;border: 0;color:#fff;background-color:#425cc6;"><a style="color: #fff; text-decoration: none;" target="_blank" href="{{ buildConsoleUrl }}"><i class="fa fa-terminal" aria-hidden="true"></i> Build Console</a></div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <table border="0" width="100%" style="border-radius: 5px;text-align: center;">
+                    <tr>
+                        <td>
+                            <div style="margin-top: 20px;">
+                                <span style="font-size:12px;">Copyright &copy; 2021 EdgeXFoundry</span>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/src/test/groovy/edgeXBuildCAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildCAppSpec.groovy
@@ -93,7 +93,8 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     BUILD_DOCKER_IMAGE: true,
                     PUSH_DOCKER_IMAGE: true,
                     SEMVER_BUMP_LEVEL: 'pre',
-                    BUILD_SNAP: false
+                    BUILD_SNAP: false,
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -136,7 +137,8 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     PUSH_DOCKER_IMAGE: true,
                     SEMVER_BUMP_LEVEL: 'patch',
                     BUILD_SNAP: false,
-                    DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"'
+                    DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"',
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildDockerSpec.groovy
+++ b/src/test/groovy/edgeXBuildDockerSpec.groovy
@@ -61,7 +61,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     PUSH_DOCKER_IMAGE: true,
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
-                    SEMVER_BUMP_LEVEL: 'patch'
+                    SEMVER_BUMP_LEVEL: 'patch',
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-devops@lists.edgexfoundry.org'
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -77,7 +78,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     DOCKER_CUSTOM_TAGS: 'MyTag1 MyTag2',
                     DOCKER_BUILD_ARGS: 'MyArg1,MyArg2',
-                    SEMVER_BUMP_LEVEL: 'pre'
+                    SEMVER_BUMP_LEVEL: 'pre',
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-devops@lists.edgexfoundry.org'
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -92,7 +94,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'pre',
-                    RELEASE_BRANCH_OVERRIDE: 'golang'
+                    RELEASE_BRANCH_OVERRIDE: 'golang',
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-devops@lists.edgexfoundry.org'
                 ], [
                     MAVEN_SETTINGS: 'MyProject-settings',
                     PROJECT: 'MyProject',
@@ -107,7 +110,8 @@ public class EdgeXBuildDockerSpec extends JenkinsPipelineSpecification {
                     ARCHIVE_IMAGE: false,
                     ARCHIVE_NAME: 'MyProject-archive.tar.gz',
                     SEMVER_BUMP_LEVEL: 'pre',
-                    RELEASE_BRANCH_OVERRIDE: 'golang'
+                    RELEASE_BRANCH_OVERRIDE: 'golang',
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -101,7 +101,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'openapi/v1',
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
-                    SHOULD_BUILD: true
+                    SHOULD_BUILD: true,
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -138,7 +139,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     // snapChannel: 'edge',
                     publishSwaggerDocs: true,
                     swaggerApiFolders: ['api/v20', 'api/v30'],
-                    artifactTypes: ['docker']
+                    artifactTypes: ['docker'],
+                    failureNotify: 'mock@lists.edgexfoundry.org'
                 ]
             ]
             expectedResult << [
@@ -169,7 +171,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_BUILD_ARGS: 'MyArg1=Value1,MyArg2="Value2"',
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
-                    SHOULD_BUILD: true
+                    SHOULD_BUILD: true,
+                    BUILD_FAILURE_NOTIFY_LIST: 'mock@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -225,7 +228,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: 'archives/bin',
                     ARTIFACT_TYPES: 'archive',
                     SHOULD_BUILD: true,
-                    ARCHIVE_ARTIFACTS: '**/*.tar.gz **/*.zip'
+                    ARCHIVE_ARTIFACTS: '**/*.tar.gz **/*.zip',
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -279,7 +283,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'openapi/v1',
                     ARTIFACT_ROOT: 'archives/bin',
                     ARTIFACT_TYPES: 'foo',
-                    SHOULD_BUILD: false
+                    SHOULD_BUILD: false,
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -101,7 +101,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     PUBLISH_SWAGGER_DOCS: false,
                     SWAGGER_API_FOLDERS: 'openapi/v1 openapi/v2',
                     // SNAP_CHANNEL: 'latest/edge',
-                    BUILD_SNAP: false
+                    BUILD_SNAP: false,
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
                 ]
             ]
     }
@@ -130,7 +131,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     goProxy: 'https://www.example.com/repository/go-proxy/',
                     useAlpineBase: true,
                     publishSwaggerDocs: true,
-                    swaggerApiFolders: ['api/v20', 'api/v30']
+                    swaggerApiFolders: ['api/v20', 'api/v30'],
+                    failureNotify: 'mock@lists.edgexfoundry.org'
                 ]
             ]
             expectedResult << [
@@ -156,7 +158,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     PUBLISH_SWAGGER_DOCS: true,
                     SWAGGER_API_FOLDERS: 'api/v20 api/v30',
                     // SNAP_CHANNEL: 'edge',
-                    BUILD_SNAP: false
+                    BUILD_SNAP: false,
+                    BUILD_FAILURE_NOTIFY_LIST: 'mock@lists.edgexfoundry.org'
                 ]
             ]
     }

--- a/src/test/groovy/edgeXEmailSpec.groovy
+++ b/src/test/groovy/edgeXEmailSpec.groovy
@@ -1,0 +1,38 @@
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+import spock.lang.Ignore
+
+public class EdgeXEmailSpec extends JenkinsPipelineSpecification {
+    def edgeXEmail = null
+
+    def setup() {
+        edgeXEmail = loadPipelineScriptForTest('vars/edgeXEmail.groovy')
+        explicitlyMockPipelineVariable('edgeXEmailUtil')
+        explicitlyMockPipelineVariable('out')
+    }
+
+    def "Test edgeXEmail [Should] send email [When] called with emailTo" () {
+        setup:
+            edgeXEmail.getBinding().setVariable('currentBuild', [ result: 'FAILURE' ])
+
+            getPipelineMock('edgeXEmailUtil.generateEmailTemplate').call() >> {
+                return 'Mock Email Template'
+            }
+        when:
+            edgeXEmail(subject: '[FAILURE] Mock Email', emailTo: 'mock@edgexfoundry.org')
+        then:
+            1 * getPipelineMock('mail').call(body: 'Mock Email Template', subject: '[FAILURE] Mock Email', to: 'mock@edgexfoundry.org', mimeType: 'text/html')
+    }
+
+    def "Test edgeXEmail [Should] NOT send email [When] called without emailTo" () {
+        setup:
+            edgeXEmail.getBinding().setVariable('currentBuild', [ result: 'FAILURE' ])
+
+            getPipelineMock('edgeXEmailUtil.generateEmailTemplate').call() >> {
+                return 'Mock Email Template'
+            }
+        when:
+            edgeXEmail(subject: '[FAILURE] Mock Email', emailTo: null)
+        then:
+            0 * getPipelineMock('mail').call(body: 'Mock Email Template', subject: '[FAILURE] Mock Email', to: null, mimeType: 'text/html')
+    }
+}

--- a/src/test/groovy/edgeXEmailUtilSpec.groovy
+++ b/src/test/groovy/edgeXEmailUtilSpec.groovy
@@ -1,0 +1,227 @@
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+import spock.lang.Ignore
+
+public class EdgeXEmailUtilSpec extends JenkinsPipelineSpecification {
+
+    def edgeXEmailUtil = null
+
+    def setup() {
+        edgeXEmailUtil = loadPipelineScriptForTest('vars/edgeXEmailUtil.groovy')
+        explicitlyMockPipelineVariable('out')
+    }
+
+    def "Test getJobDetailsJson [Should] generate expected object with branch override [When] build fails" () {
+        setup:
+            def environmentVariables = [
+                'GIT_BASE':     'https://github.com/edgexfoundry/$PROJECT',
+                'GIT_URL':      'git@github.com:edgexfoundry/edgex-global-pipelines.git',
+                'GIT_BRANCH':   'override-branch-name',
+                'JOB_NAME':     'edgexfoundry/mock-job/master',
+                'BUILD_NUMBER': '1',
+                'BUILD_URL':    'https://jenkins.edgexfoundry.org/mock-job/1/',
+                'JENKINS_URL':  'https://jenkins.edgexfoundry.org'
+            ]
+            edgeXEmailUtil.getBinding().setVariable('env', environmentVariables)
+            edgeXEmailUtil.getBinding().setVariable('currentBuild', [ result: 'FAILURE', durationString: '4m 20s and counting' ])
+
+            setupMockGitCalls()
+            setupMockBuildLog()
+
+        expect:
+            edgeXEmailUtil.getJobDetailsJson() == expectedResult
+        where:
+            expectedResult = [
+                jobName: "edgexfoundry/mock-job/master #1",
+                buildNumber: '1',
+                buildUrl: 'https://jenkins.edgexfoundry.org/mock-job/1/',
+                gitUrl: 'https://github.com/edgexfoundry/edgex-global-pipelines.git',
+                buildConsoleUrl: "https://jenkins.edgexfoundry.org/mock-job/1/console",
+                color: '#e60d49',
+                status: 'FAILURE',
+                author: 'mock-author',
+                branch: 'override-branch-name',
+                duration: '4m 20s',
+                commitMessage: 'mock-message',
+                failedStage: 'mock-failed-stage',
+                changeLog: ['mock-changelog-item-1', 'mock-changelog-item-2'],
+                buildLog: 'mock-build-log'
+            ]
+    }
+
+    def "Test getJobDetailsJson [Should] generate expected object [When] build fails" () {
+        setup:
+            def environmentVariables = [
+                'GIT_BASE':     'https://github.com/edgexfoundry/$PROJECT',
+                'GIT_URL':      'git@github.com:edgexfoundry/edgex-global-pipelines.git',
+                'JOB_NAME':     'edgexfoundry/mock-job/master',
+                'BUILD_NUMBER': '1',
+                'BUILD_URL':    'https://jenkins.edgexfoundry.org/mock-job/1/',
+                'JENKINS_URL':  'https://jenkins.edgexfoundry.org'
+            ]
+            edgeXEmailUtil.getBinding().setVariable('env', environmentVariables)
+            edgeXEmailUtil.getBinding().setVariable('currentBuild', [ result: 'FAILURE', durationString: '4m 20s and counting' ])
+
+            setupMockGitCalls()
+            setupMockBuildLog()
+
+        expect:
+            edgeXEmailUtil.getJobDetailsJson() == expectedResult
+        where:
+            expectedResult = [
+                jobName: "edgexfoundry/mock-job/master #1",
+                buildNumber: '1',
+                buildUrl: 'https://jenkins.edgexfoundry.org/mock-job/1/',
+                gitUrl: 'https://github.com/edgexfoundry/edgex-global-pipelines.git',
+                buildConsoleUrl: "https://jenkins.edgexfoundry.org/mock-job/1/console",
+                color: '#e60d49',
+                status: 'FAILURE',
+                author: 'mock-author',
+                branch: 'mock-branch',
+                duration: '4m 20s',
+                commitMessage: 'mock-message',
+                failedStage: 'mock-failed-stage',
+                changeLog: ['mock-changelog-item-1', 'mock-changelog-item-2'],
+                buildLog: 'mock-build-log'
+            ]
+    }
+
+    def "Test getJobDetailsJson [Should] generate expected object with error handling [When] build fails" () {
+        setup:
+            def environmentVariables = [
+                'GIT_BASE':     'https://github.com/edgexfoundry/$PROJECT',
+                'GIT_URL':      'git@github.com:edgexfoundry/edgex-global-pipelines.git',
+                'JOB_NAME':     'edgexfoundry/mock-job/master',
+                'BUILD_NUMBER': '1',
+                'BUILD_URL':    'https://jenkins.edgexfoundry.org/mock-job/1/',
+                'JENKINS_URL':  'https://jenkins.edgexfoundry.org'
+            ]
+            edgeXEmailUtil.getBinding().setVariable('env', environmentVariables)
+            edgeXEmailUtil.getBinding().setVariable('currentBuild', [ result: 'FAILURE', durationString: '4m 20s and counting' ])
+
+            setupErrorGitCalls()
+            setupErrorBuildLog()
+
+        expect:
+            edgeXEmailUtil.getJobDetailsJson() == expectedResult
+        where:
+            expectedResult = [
+                jobName: "edgexfoundry/mock-job/master #1",
+                buildNumber: '1',
+                buildUrl: 'https://jenkins.edgexfoundry.org/mock-job/1/',
+                gitUrl: 'https://github.com/edgexfoundry/edgex-global-pipelines.git',
+                buildConsoleUrl: "https://jenkins.edgexfoundry.org/mock-job/1/console",
+                color: '#e60d49',
+                status: 'FAILURE',
+                author: 'Unknown Author',
+                branch: 'Unknown Branch',
+                duration: '4m 20s',
+                commitMessage: 'Unknown Commit Message',
+                failedStage: 'Could not determine failed stage',
+                changeLog: [],
+                buildLog: 'An error occurred getting build log details...'
+            ]
+    }
+
+    def "Test generateEmailTemplate [Should] generate expected email html template [When] build fails" () {
+        setup:
+            def environmentVariables = [
+                'GIT_BASE':     'https://github.com/edgexfoundry/$PROJECT',
+                'GIT_URL':      'git@github.com:edgexfoundry/edgex-global-pipelines.git',
+                'JOB_NAME':     'edgexfoundry/mock-job/master',
+                'BUILD_NUMBER': '1',
+                'BUILD_URL':    'https://jenkins.edgexfoundry.org/mock-job/1/',
+                'JENKINS_URL':  'https://jenkins.edgexfoundry.org',
+                'WORKSPACE': '/mock/workspace'
+            ]
+            edgeXEmailUtil.getBinding().setVariable('env', environmentVariables)
+            edgeXEmailUtil.getBinding().setVariable('currentBuild', [ result: 'FAILURE', durationString: '4m 20s and counting' ])
+
+            setupMockGitCalls()
+            setupMockBuildLog()
+
+            getPipelineMock('libraryResource')('email/build-notification-template.html') >> {
+                return 'mock-template'
+            }
+
+            getPipelineMock('docker.image')('node:alpine') >> explicitlyMockPipelineVariable('DockerImageMock')
+
+            def jobJsonMock = [
+                jobName: "edgexfoundry/mock-job/master #1",
+                buildNumber: '1',
+                buildUrl: 'https://jenkins.edgexfoundry.org/mock-job/1/',
+                gitUrl: 'https://github.com/edgexfoundry/edgex-global-pipelines.git',
+                buildConsoleUrl: "https://jenkins.edgexfoundry.org/mock-job/1/console",
+                color: '#e60d49',
+                status: 'FAILURE',
+                author: 'mock-author',
+                branch: 'mock-branch',
+                duration: '4m 20s',
+                commitMessage: 'mock-message',
+                failedStage: 'mock-failed-stage',
+                changeLog: ['mock-changelog-item-1', 'mock-changelog-item-2'],
+                buildLog: 'mock-build-log'
+            ]
+
+        when:
+            
+
+            edgeXEmailUtil.generateEmailTemplate()
+        then:
+            1 * getPipelineMock('writeJSON').call(file: '/tmp/jobdetails-1.json', json: jobJsonMock)
+            1 * getPipelineMock('writeFile').call(file: '/tmp/job-email-template.html', text: 'mock-template')
+            1 * getPipelineMock('DockerImageMock.inside').call(_) >> { _arguments ->
+                assert "-u 0:0 -v /tmp:/tmp" == _arguments[0][0]
+            }
+            1 * getPipelineMock('sh').call('npm install -g mustache')
+            1 * getPipelineMock('sh').call('mustache /tmp/jobdetails-1.json /tmp/job-email-template.html /mock/workspace/email-rendered.html')
+            1 * getPipelineMock('readFile').call('./email-rendered.html')
+    }
+
+    def setupMockGitCalls() {
+        getPipelineMock('sh').call([script: 'git rev-parse HEAD', returnStdout:true]) >> 'mock-git-commit'
+        getPipelineMock('sh').call([script: 'git --no-pager show -s --format=\'%an\' mock-git-commit', returnStdout:true]) >> 'mock-author'
+        getPipelineMock('sh').call([script: 'git log -1 --pretty=%B', returnStdout:true]) >> 'mock-message'
+        getPipelineMock('sh').call([script: 'git log -m -1 --name-only --pretty=\'format:\' mock-git-commit', returnStdout:true]) >> 'mock-changelog-item-1\nmock-changelog-item-2'
+        getPipelineMock('sh').call([script: 'git rev-parse --abbrev-ref HEAD', returnStdout:true]) >> 'mock-branch'
+    }
+
+    def setupErrorGitCalls() {
+        getPipelineMock('sh').call([script: 'git rev-parse HEAD', returnStdout:true]) >> 'mock-git-commit'
+
+        getPipelineMock('sh').call([script: 'git --no-pager show -s --format=\'%an\' mock-git-commit', returnStdout:true]) >> {
+            throw new Exception('error')
+        }
+
+        getPipelineMock('sh').call([script: 'git log -1 --pretty=%B', returnStdout:true]) >> {
+            throw new Exception('error')
+        }
+
+        getPipelineMock('sh').call([script: 'git log -m -1 --name-only --pretty=\'format:\' mock-git-commit', returnStdout:true]) >> {
+            throw new Exception('error')
+        }
+
+        getPipelineMock('sh').call([script: 'git rev-parse --abbrev-ref HEAD', returnStdout:true]) >> {
+            throw new Exception('error')
+        }
+    }
+
+    def setupMockBuildLog() {
+        getPipelineMock('libraryResource')('build-log-extract.sh') >> {
+            return 'build-log-extract'
+        }
+
+        // mock the format of build-log-extract.sh
+        getPipelineMock('sh').call([script: 'build-log-extract', returnStdout:true]) >> '''mock-failed-stage
+^^^^^^^^^^^^
+mock-build-log'''
+    }
+
+    def setupErrorBuildLog() {
+        getPipelineMock('libraryResource')('build-log-extract.sh') >> {
+            return 'build-log-extract'
+        }
+
+        // mock the format of build-log-extract.sh
+        getPipelineMock('sh').call([script: 'build-log-extract', returnStdout:true]) >> ''
+    }
+}

--- a/vars/edgeXEmail.groovy
+++ b/vars/edgeXEmail.groovy
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+    Usage: 
+*/
+
+def call(config = [:]) {
+    def renderedEmailTemplate = edgeXEmailUtil.generateEmailTemplate()
+
+    // println "We have email HTML to send?" //debug
+    // println renderedEmailTemplate //debug
+
+    def buildStatus = currentBuild.result == null ? "SUCCESS" : currentBuild.result
+    def subject     = config.subject ?: "[${buildStatus}] ${env.JOB_NAME} Build #${env.BUILD_NUMBER}"
+    def recipients  = config.emailTo
+
+    println "[edgeXEmailHelper] config: ${config}"
+
+    if(renderedEmailTemplate && recipients) {
+        mail body: renderedEmailTemplate, subject: subject, to: recipients, mimeType: 'text/html'
+    } else {
+        println "[edgeXEmailHelper] No email message could be generated. Not sending email"
+    }
+}

--- a/vars/edgeXEmailUtil.groovy
+++ b/vars/edgeXEmailUtil.groovy
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+def getJobDetailsJson() {
+    def colorMap = [
+        UNSTABLE: "#ffa84f",
+        FAILURE: "#e60d49",
+        SUCCESS: "#2dce84"
+    ]
+
+    // Due to some inaccuracies with Jenkins GIT env vars, need to grab details with git commands
+    def commit, author, message, changeLog, branch
+
+    try {
+        commit = sh(returnStdout: true, script: 'git rev-parse HEAD')
+    } catch(ex) {}
+    
+    if(commit) {
+        try {
+            author = sh(returnStdout: true, script: "git --no-pager show -s --format='%an' ${commit}").trim()
+        } catch(ex) {
+            author = 'Unknown Author'
+        }
+
+        try {
+            message = sh(returnStdout: true, script: 'git log -1 --pretty=%B').trim()
+        } catch(ex) {
+            message = 'Unknown Commit Message'
+        }
+
+        try {
+            changeLogText = sh(returnStdout: true, script: "git log -m -1 --name-only --pretty='format:' ${commit}")
+            changeLog = changeLogText.trim().split('\n')
+        } catch(ex) {
+            changeLog = []
+        }
+
+        try {
+            branch = env.GIT_BRANCH ?: sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
+        } catch(ex) {
+            branch = 'Unknown Branch'
+        }
+    }
+
+    def gitUrl
+    if(env.GIT_BASE) {
+        // Get a clean GIT url base
+        def gitBase = env.GIT_BASE.substring(0, env.GIT_BASE.indexOf('edgexfoundry/$PROJECT'))
+        gitUrl = "${env.GIT_URL.contains('git@') ? gitBase + env.GIT_URL.split(':')[1] : env.GIT_URL}"
+    }
+
+    def buildStatus = currentBuild.result == null ? "SUCCESS" : currentBuild.result // build result is null if the job is not completed
+    def extractedBuildLog = sh(script: libraryResource('build-log-extract.sh'), returnStdout: true).trim()
+
+    def extractedBuildLogSplit = extractedBuildLog.split('\n')
+    def failedStage = extractedBuildLog ? extractedBuildLogSplit[0] : 'Could not determine failed stage'
+
+    def buildLog
+
+    if(extractedBuildLog) {
+        buildLog = []
+        for(def i = 2; i < extractedBuildLogSplit.size(); i++) { // drop the first two lines
+            buildLog << extractedBuildLogSplit[i]
+        }
+        buildLog = buildLog.join('\n')
+    } else {
+        buildLog = 'An error occurred getting build log details...'
+    }
+
+    def buildColor  = colorMap[buildStatus]
+
+    def jobDetails = [
+        jobName: "${env.JOB_NAME} #${env.BUILD_NUMBER}",
+        buildNumber: env.BUILD_NUMBER,
+        buildUrl: env.BUILD_URL,
+        gitUrl: gitUrl,
+        buildConsoleUrl: "${env.BUILD_URL}console",
+        color: buildColor,
+        status: buildStatus,
+        author: author,
+        branch: branch,
+        duration: currentBuild.durationString.replaceAll(' and counting', ''),
+        commitMessage: message,
+        failedStage: failedStage,
+        changeLog: changeLog,
+        buildLog: buildLog
+    ]
+
+    println "[edgeXEmailUtil] Job JSON"
+    println jobDetails
+
+    jobDetails
+}
+
+// my approach for this is to write the job details to a JSON file
+// then use a templating tool to merge a tem
+def generateEmailTemplate(jobDetails) {
+    // allow jobDetails to be passed in for easier unit testing
+    jobDetails = jobDetails == null ? getJobDetailsJson() : jobDetails
+
+    def emailHTML
+    if(jobDetails) {
+        println "Writing Job Details to JSON"
+        
+        def jsonFile = "/tmp/jobdetails-${env.BUILD_NUMBER}.json"
+        writeJSON file: jsonFile, json: jobDetails
+
+        // need to write this the local workspace
+        def emailTemplate = libraryResource('email/build-notification-template.html')
+        writeFile file: '/tmp/job-email-template.html', text: emailTemplate
+
+        docker.image('node:alpine').inside('-u 0:0 -v /tmp:/tmp') {
+            sh 'npm install -g mustache' // slightly inneficient
+            sh "mustache ${jsonFile} /tmp/job-email-template.html ${env.WORKSPACE}/email-rendered.html" // file needs to be written to workspace for readFile to work properly
+        }
+
+        emailHTML = readFile './email-rendered.html'
+    }
+
+    emailHTML
+}

--- a/vars/edgeXInfraPublish.groovy
+++ b/vars/edgeXInfraPublish.groovy
@@ -65,8 +65,6 @@ def call(body) {
                 println "[edgeXInfraPublish] An error occurd while publishing logs: ${e.message}"
             }
         }
-
-        cleanWs()
     }
 }
 


### PR DESCRIPTION
New feature to send emails for build failures.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#312 

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
