### PR TITLE
Parallel jobs: get cost data from dynamic nodes

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -1,5 +1,6 @@
+import org.jenkinsci.plugins.workflow.libs.Library
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2019-2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,19 +14,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+@Library("lf-pipelines") _
 
 /**
  #edgeXBuildGoApp
- 
+
  Shared Library to build Go projects
- 
+
  ## Parameters
 
  * **project** - Specify your project name
  * **goVersion** - Go version
- 
+
  ## Usage
- 
+
  ### Basic example
 
  ```groovy
@@ -34,9 +36,9 @@
      goVersion: '1.15'
  )
  ```
- 
+
  ### Complex example
- 
+
  ```groovy
  edgeXBuildGoApp (
      project: 'app-functions-sdk-go',
@@ -89,7 +91,7 @@ def call(config) {
             stage('Prepare') {
                 steps {
                     script {
-                        edgex.releaseInfo() 
+                        edgex.releaseInfo()
                         edgeXSetupEnvironment(_envVarMap)
                         // docker login for the to make sure all docker commands are authenticated
                         // in this specific node
@@ -193,7 +195,7 @@ def call(config) {
                             }
 
                             stage('Docker Push') {
-                                when { 
+                                when {
                                     allOf {
                                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
@@ -227,6 +229,11 @@ def call(config) {
                                 steps {
                                     edgeXSnap()
                                 }
+                            }
+                        }
+                        post {
+                            always {
+                                lfParallelCostCapture()
                             }
                         }
                     }
@@ -293,7 +300,7 @@ def call(config) {
                             }
 
                             stage('Docker Push') {
-                                when { 
+                                when {
                                     allOf {
                                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
@@ -329,6 +336,11 @@ def call(config) {
                                     edgeXSnap()
                                 }
                             }*/
+                        }
+                        post {
+                            always {
+                                lfParallelCostCapture()
+                            }
                         }
                     }
                 }

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -1,5 +1,6 @@
+import org.jenkinsci.plugins.workflow.libs.Library
 //
-// Copyright (c) 2020 Intel Corporation
+// Copyright (c) 2019-2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+@Library("lf-pipelines") _
 
 /**
  #edgeXBuildGoParallel
- 
+
  Shared Library to build Go projects and Docker images in parallel. Utilizes docker-compose --parallel to build Docker images found in the workspace. Currently only used for the **edgex-go** mono-repo.
- 
+
  ## Parameters
 
  * **project** - **Required** Specify your project name
@@ -26,7 +28,7 @@
  * more coming soon...
 
  ## Usage
- 
+
  ### Basic example
 
  ```groovy
@@ -35,9 +37,9 @@
      dockerFileGlobPath: 'cmd/** /Dockerfile',
  )
  ```
- 
+
  ### Complex example
- 
+
  ```groovy
  edgeXBuildGoParallel(
     project: 'edgex-go',
@@ -147,7 +149,7 @@ def call(config) {
                                 steps {
                                     script {
                                         // docker.sock bind mount needed due to `make raml_verify` launching a docker image
-                                        // docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: 
+                                        // docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock:
                                         docker.image("ci-base-image-${env.ARCH}")
                                             .inside('-u 0:0 -v /var/run/docker.sock:/var/run/docker.sock --privileged')
                                         {
@@ -167,7 +169,7 @@ def call(config) {
                             }
 
                             stage('Docker Push') {
-                                when { 
+                                when {
                                     allOf {
                                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
@@ -248,7 +250,7 @@ def call(config) {
                                 steps {
                                     script {
                                         // docker.sock bind mount needed due to `make raml_verify` launching a docker image
-                                        //docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: 
+                                        //docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock:
                                         docker.image("ci-base-image-${env.ARCH}")
                                             .inside('-u 0:0 -v /var/run/docker.sock:/var/run/docker.sock --privileged')
                                         {
@@ -268,7 +270,7 @@ def call(config) {
                             }
 
                             stage('Docker Push') {
-                                when { 
+                                when {
                                     allOf {
                                         environment name: 'BUILD_DOCKER_IMAGE', value: 'true'
                                         environment name: 'PUSH_DOCKER_IMAGE', value: 'true'
@@ -304,6 +306,11 @@ def call(config) {
                                     edgeXSnap()
                                 }
                             }*/
+                        }
+                        post {
+                            always {
+                                lfParallelCostCapture()
+                            }
                         }
                     }
                 }

--- a/vars/edgeXGeneric.groovy
+++ b/vars/edgeXGeneric.groovy
@@ -1,4 +1,22 @@
 import com.cloudbees.groovy.cps.NonCPS
+import org.jenkinsci.plugins.workflow.libs.Library
+//
+// Copyright (c) 2019-2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+@Library("lf-pipelines") _
+
 /*edgeXGeneric([
     project: 'edgex-go',
     mavenSettings: ['edgex-go-codecov-token:CODECOV_TOKEN'], (optional)
@@ -70,7 +88,7 @@ def call(config) {
                     edgeXSemver 'init' // <-- Generates a VERSION file and .semver directory
                 }
             }
-            
+
             stage('Build') {
                 parallel {
                     stage('amd64') {
@@ -248,6 +266,11 @@ def call(config) {
                                         }
                                     }
                                 }
+                            }
+                        }
+                        post {
+                            always {
+                                lfParallelCostCapture()
                             }
                         }
                     }


### PR DESCRIPTION
Previously, the LF's job cost scripts could not take into account the
agents that are dynamically allocated when an "agent" block is used
within a parallel stage. A new function has been added to the LF's
pipeline library that is intended to be run in a post block after any
parallel stage that uses a new agent.

This change also includes some minor whitespace cleanup in affected
files, as well as adding a license to edgeXGeneric and updating
copyright dates.

Issue: LF-Jira RELENG-3207
Signed-off-by: Eric Ball <eball@linuxfoundation.org>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
