### PR TITLE
fix: reference to old email method

### DIFF
--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -371,7 +371,7 @@ def call(config) {
                     currentBuild.result = 'FAILED'
                     // only send email when on a release stream branch i.e. main, hanoi, ireland, etc.
                     if(edgex.isReleaseStream()) {
-                        edgeXEmailHelper.sendBuildDetailsEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
+                        edgeXEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
                     }
                 }
             }

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -294,7 +294,7 @@ def call(config) {
                     currentBuild.result = 'FAILED'
                     // only send email when on a release stream branch i.e. main, hanoi, ireland, etc.
                     if(edgex.isReleaseStream()) {
-                        edgeXEmailHelper.sendBuildDetailsEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
+                        edgeXEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
                     }
                 }
             }

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -474,7 +474,7 @@ def call(config) {
                     currentBuild.result = 'FAILED'
                     // only send email when on a release stream branch i.e. main, hanoi, ireland, etc.
                     if(edgex.isReleaseStream()) {
-                        edgeXEmailHelper.sendBuildDetailsEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
+                        edgeXEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
                     }
                 }
             }

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -385,7 +385,7 @@ def call(config) {
                     currentBuild.result = 'FAILED'
                     // only send email when on a release stream branch i.e. main, hanoi, ireland, etc.
                     if(edgex.isReleaseStream()) {
-                        edgeXEmailHelper.sendBuildDetailsEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
+                        edgeXEmail(emailTo: env.BUILD_FAILURE_NOTIFY_LIST)
                     }
                 }
             }


### PR DESCRIPTION
Fix a reference to an old method I initially setup and refactored to the edgeXEmail class.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
