### PR TITLE
fix: jobDetails should be defaulted to null

### DIFF
--- a/vars/edgeXEmailUtil.groovy
+++ b/vars/edgeXEmailUtil.groovy
@@ -107,7 +107,7 @@ def getJobDetailsJson() {
 
 // my approach for this is to write the job details to a JSON file
 // then use a templating tool to merge a tem
-def generateEmailTemplate(jobDetails) {
+def generateEmailTemplate(jobDetails = null) {
     // allow jobDetails to be passed in for easier unit testing
     jobDetails = jobDetails == null ? getJobDetailsJson() : jobDetails
 


### PR DESCRIPTION
`jobDetails` parameter of generateEmailTemplate should be defaulted null to allow empty parameters.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
