### PR TITLE
fix: update permission for build artifacts

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -29,7 +29,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
  Name | Required | Type | Description and Default Value
  -- | -- | -- | --
- project | required | str | The name of your project. | 
+ project | required | str | The name of your project. |
  mavenSettings | optional | str | The maven settings file in Jenkins that has been created for your project. **Note** the maven settings file specified must exist in Jenkins in order for your project to build.<br /><br />**Default**: `${project}-settings`
  semver | optional | bool | Specify if semantic versioning will be used to version your project. **Note** edgeX utilizes [git-semver](https://github.com/edgexfoundry/git-semver) for semantic versioning.<br /><br />**Default**: `true`
  testScript | optional | str | The command the build will use to test your project. **Note** the specified test script will execute in the project's CI build container.<br /><br />**Default**: `make test`
@@ -587,6 +587,8 @@ def buildArtifact() {
     if(artifactTypes.contains('archive')) {
         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
             sh env.BUILD_SCRIPT
+            // change permissions of archive root parent directory
+            sh 'chown -R 1001:1001 ${ARTIFACT_ROOT}/..'
         }
         stash name: "artifacts-${env.ARCH}", includes: "${env.ARTIFACT_ROOT}/**", useDefaultExcludes: false, allowEmpty: true
     }


### PR DESCRIPTION
Fixes permissions with the archives directory. The default value of `ARTIFACT_ROOT` is `archives/bin`, so the chown is applied to the parent directory hence the `chown ... ${ARTIFACT_ROOT}/..`. I did not want to hardcode the directory so that is why I did the `..`

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links : https://jenkins.edgexfoundry.org/sandbox/job/Functional-Testing/job/edgex-cli-test/4/console

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
