### PR TITLE
fix: ensure bump always happens if tag happens.

### DIFF
--- a/vars/edgeXRelease.groovy
+++ b/vars/edgeXRelease.groovy
@@ -40,11 +40,14 @@ def parallelStepFactoryTransform(step) {
                 stage("Git Tag Publish") {
                     edgeXReleaseGitTag(step, [credentials: "edgex-jenkins-ssh", bump: false, tag: true])
                 }
-                stage("Stage Artifact") {
-                    stageArtifact(step)
-                }
-                stage("Bump Semver") {
-                    edgeXReleaseGitTag(step, [credentials: "edgex-jenkins-ssh", bump: true, tag: false])
+                try{
+                    stage("Stage Artifact") {
+                        stageArtifact(step)
+                    }
+                }finally {
+                    stage("Bump Semver"){
+                        edgeXReleaseGitTag(step, [credentials: "edgex-jenkins-ssh", bump: true, tag: false])
+                    }
                 }
             }
             


### PR DESCRIPTION
This addresses [#115 - EdgeX DevOps: release automation fails to bump semver tag when re-releasing a repo with the same version](https://github.com/edgexfoundry/cd-management/issues/115)

**Prior Behavior:**
**cd-management releases sample-service 4.1.36**
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/view/change-requests/job/PR-151/1/console

**Sample service failed when staged.** 
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/144/
This causes sample-service to be tagged to 4.1.36 but fails to bump the version so semver is set to 4.1.36 afterwards

![image](https://user-images.githubusercontent.com/61600932/120044678-2548fb80-bfc3-11eb-8052-5e88387b3d25.png)


Subsequent sample-service builds fail due to it being tagged at 4.1.36 and semver being set to 4.1.36 still. It also will not bump semver to get out of this stuck state.
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/master/145/
![image](https://user-images.githubusercontent.com/61600932/120044791-617c5c00-bfc3-11eb-88ce-f3a171203c34.png)

Rerunning the cd-management job for version 4.1.36 after sample-service is fixed still causes semver not to bump due to it ignoring the command since it's already tagged:  [This happened in the original issue with device-bacnet-c in November 2020](https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fdevice-bacnet-c/detail/master/13/pipeline/437):

> [2020-11-18T21:37:26.547Z] [edgeXSemver]: ignoring command push because GITSEMVER_HEAD_TAG is already set to 'v1.3.0'

Whereas the gitsemver is used for all builds at all times, the release process isn't used very often or in as many places. Adding features to gitsemver to force/ignore certain conditions seemed to be more intrusive.

 Ensuring this sequencing of tag/stage/bump is always done together in edgeXrelease seems like a safer solution:

**New Behavior:
cd-management release sample-service 4.1.43**
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fcd-management/detail/PR-151/8/pipeline/191
Triggers sample-service (which is forced to fail for testing) but it still does a semver bump to place it back in a working state.
![image](https://user-images.githubusercontent.com/61600932/120044899-9f798000-bfc3-11eb-9fe4-53f5135b4194.png)


https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/build-failure/5/console
Cd-management still comes out of the stage artifact failure and bumps sample-service to 4.1.44-dev.1

The build still shows a failure so the person doing the release knows to address the underling problem and the semver version is not in a "stuck" state that will prevent future build failures or bumps.


Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
cd-management #115

## Sandbox Testing
Test Links :
See description to relevant functional testing links.
## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
