### PR TITLE
fix: use regex for default docker image name

### DIFF
--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -500,7 +500,7 @@ def toEnvironment(config) {
     def _dockerBuildImageTarget = config.dockerBuildImageTarget ?: 'builder'
     def _dockerBuildArgs     = config.dockerBuildArgs ?: []
     def _dockerNamespace     = config.dockerNamespace ?: '' //default for edgex is empty string
-    def _dockerImageName     = config.dockerImageName ?: _projectName.replaceAll('-c', '')
+    def _dockerImageName     = config.dockerImageName ?: _projectName.replaceAll(/-c$/, '')
     def _dockerNexusRepo     = config.dockerNexusRepo ?: 'staging'
     def _buildImage          = edgex.defaultTrue(config.buildImage)
     def _pushImage           = edgex.defaultTrue(config.pushImage)


### PR DESCRIPTION
Should fix issues with image names like:

Before:
```
device-coap-c --> deviceoap
device-cranberry-c --> deviceranberry
```

After:
```
device-coap-c --> device-coap
device-cranberry-c --> device-cranberry
```
etc

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
