### PR TITLE
Pipeline optimizations

### DIFF
--- a/src/test/groovy/edgeXInfraPublishSpec.groovy
+++ b/src/test/groovy/edgeXInfraPublishSpec.groovy
@@ -30,7 +30,7 @@ public class EdgeXInfraPublishSpec extends JenkinsPipelineSpecification {
             getPipelineMock("libraryResource")('global-jjb-shell/package-listing.sh') >> {
                 return 'package-listing'
             }
-            getPipelineMock('docker.image')('MyDockerRegistry:10003/edgex-lftools-log-publisher:alpine') >> explicitlyMockPipelineVariable('DockerImageMock')
+            getPipelineMock('docker.image')('MyDockerRegistry:10003/edgex-lftools-log-publisher:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
         when:
             edgeXInfraPublish()
         then:
@@ -42,8 +42,8 @@ public class EdgeXInfraPublishSpec extends JenkinsPipelineSpecification {
                 assert dockerArgs == _arguments[0][0]
             }
             1 * getPipelineMock('sh').call('touch /tmp/pre-build-complete')
-            1 * getPipelineMock('sh').call('mkdir -p /var/log/sa')
-            1 * getPipelineMock('sh').call('for file in `ls /var/log/sa-host`; do sadf -c /var/log/sa-host/${file} > /var/log/sa/${file}; done')
+            1 * getPipelineMock('sh').call('mkdir -p /var/log/sysstat')
+            1 * getPipelineMock('sh').call('for file in `ls /var/log/sa-host`; do sadf -c /var/log/sa-host/${file} > /var/log/sysstat/${file}; done')
     }
 
     def "Test getLogPublishContainerArgs [Should] return expected #expectedResult [When] called" () {

--- a/src/test/groovy/edgeXInfraShipLogsSpec.groovy
+++ b/src/test/groovy/edgeXInfraShipLogsSpec.groovy
@@ -37,7 +37,7 @@ public class EdgeXInfraShipLogsSpec extends JenkinsPipelineSpecification {
         when:
             edgeXInfraShipLogs()
         then:
-            1 * getPipelineMock('docker.image')('MyDockerRegistry:10003/edgex-lftools-log-publisher:alpine') >> explicitlyMockPipelineVariable('DockerImageMock')
+            1 * getPipelineMock('docker.image')('MyDockerRegistry:10003/edgex-lftools-log-publisher:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
             1 * getPipelineMock('DockerImageMock.inside').call(_) >> { _arguments ->
                 def dockerArgs = '--privileged -u 0:0 -v /var/log/sa:/var/log/sa-host'
                 assert dockerArgs == _arguments[0][0]

--- a/src/test/groovy/edgexSpec.groovy
+++ b/src/test/groovy/edgexSpec.groovy
@@ -647,4 +647,23 @@ public class EdgeXSpec extends JenkinsPipelineSpecification {
             ]
     }
 
+    def "Test parallelJobCost [Should] call lfParallelCostCapture inside a docker image [When] called with no params" () {
+        setup:
+            explicitlyMockPipelineVariable('lfParallelCostCapture')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-lftools-log-publisher:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeX.parallelJobCost()
+        then:
+            1 * getPipelineMock('lfParallelCostCapture.call').call()
+    }
+
+    def "Test parallelJobCost [Should] call lfParallelCostCapture inside a docker image [When] called with no tag parameter" () {
+        setup:
+            explicitlyMockPipelineVariable('lfParallelCostCapture')
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-lftools-log-publisher:arm64') >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeX.parallelJobCost('arm64')
+        then:
+            1 * getPipelineMock('lfParallelCostCapture.call').call()
+    }
 }

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -179,7 +179,6 @@ def call(config) {
                                         }
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
                                             edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         }
@@ -249,6 +248,11 @@ def call(config) {
                                 }
                             }
                         }
+                        post {
+                            always {
+                                script { edgex.parallelJobCost() }
+                            }
+                        }
                     }
 
                     stage('arm64') {
@@ -272,7 +276,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
@@ -344,6 +347,11 @@ def call(config) {
                                     }
                                 }
                             }*/
+                        }
+                        post {
+                            always {
+                                script { edgex.parallelJobCost('arm64') }
+                            }
                         }
                     }
                 }
@@ -522,11 +530,4 @@ def toEnvironment(config) {
     edgex.printMap envMap
 
     envMap
-}
-
-// Temp fix while LF updates base packer images
-def enableDockerProxy(proxyHost, debug = false) {
-    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
-    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
-    sh 'sudo service docker restart | true'
 }

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -179,7 +179,7 @@ def call(config) {
                                         }
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
                                             edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         }
@@ -272,7 +272,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -167,7 +167,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -218,6 +217,11 @@ def call(config) {
                                 }
                             }
                         }
+                        post {
+                            always {
+                                script { edgex.parallelJobCost() }
+                            }
+                        }
                     }
 
                     stage('arm64') {
@@ -236,7 +240,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -284,6 +287,11 @@ def call(config) {
                                         }
                                     }
                                 }
+                            }
+                        }
+                        post {
+                            always {
+                                script { edgex.parallelJobCost('arm64') }
                             }
                         }
                     }
@@ -424,11 +432,4 @@ def toEnvironment(config) {
     edgex.printMap envMap
 
     envMap
-}
-
-// Temp fix while LF updates base packer images
-def enableDockerProxy(proxyHost, debug = false) {
-    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
-    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
-    sh 'sudo service docker restart | true'
 }

--- a/vars/edgeXBuildDocker.groovy
+++ b/vars/edgeXBuildDocker.groovy
@@ -167,7 +167,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -205,7 +205,7 @@ def call(config) {
                                 when {
                                     environment name: 'ARCHIVE_IMAGE', value: 'true'
                                 }
-                                
+
                                 steps {
                                     script {
                                         withEnv(["IMAGE=${edgeXDocker.finalImageName("${DOCKER_IMAGE_NAME}")}"]) {
@@ -214,7 +214,7 @@ def call(config) {
                                             archiveArtifacts allowEmptyArchive: true, artifacts: '*.tar.gz', fingerprint: true, onlyIfSuccessful: true
                                         }
                                     }
-                                    
+
                                 }
                             }
                         }
@@ -236,7 +236,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
@@ -274,7 +274,7 @@ def call(config) {
                                 when {
                                     environment name: 'ARCHIVE_IMAGE', value: 'true'
                                 }
-                                
+
                                 steps {
                                     script {
                                         withEnv(["IMAGE=${edgeXDocker.finalImageName("${DOCKER_IMAGE_NAME}-${ARCH}")}"]) {

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -222,7 +222,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
@@ -328,7 +328,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -222,7 +222,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
@@ -302,7 +301,7 @@ def call(config) {
                         }
                         post {
                             always {
-                                lfParallelCostCapture()
+                                script { edgex.parallelJobCost() }
                             }
                         }
                     }
@@ -328,9 +327,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
-                                        // docker login for the to make sure all docker commands are authenticated
-                                        // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
                                             edgeXDockerLogin(settingsFile: env.MAVEN_SETTINGS)
                                         }
@@ -411,7 +407,7 @@ def call(config) {
                         }
                         post {
                             always {
-                                lfParallelCostCapture()
+                                script { edgex.parallelJobCost('arm64') }
                             }
                         }
                     }
@@ -720,11 +716,4 @@ def toEnvironment(config) {
     edgex.printMap envMap
 
     envMap
-}
-
-// Temp fix while LF updates base packer images
-def enableDockerProxy(proxyHost, debug = false) {
-    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
-    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
-    sh 'sudo service docker restart | true'
 }

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -190,7 +190,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // builds ci-base-image used to cache dependencies and system libs
                                         prepBaseBuildImage()
                                         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') { sh 'go version' }
@@ -285,7 +285,7 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
+                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -190,7 +190,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // builds ci-base-image used to cache dependencies and system libs
                                         prepBaseBuildImage()
                                         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') { sh 'go version' }
@@ -285,7 +284,6 @@ def call(config) {
                                         if(params.CommitId) {
                                             sh "git checkout ${params.CommitId}"
                                         }
-                                        // enableDockerProxy('https://nexus3.edgexfoundry.org:10001')
                                         // docker login for the to make sure all docker commands are authenticated
                                         // in this specific node
                                         if(env.BUILD_DOCKER_IMAGE == 'true') {
@@ -366,7 +364,7 @@ def call(config) {
                         }
                         post {
                             always {
-                                lfParallelCostCapture()
+                                script { edgex.parallelJobCost('arm64') }
                             }
                         }
                     }
@@ -600,11 +598,4 @@ def getDockerfilesFromTagged(tagged, dockers) {
             [it, dockers.find { imgSpec -> imageName =~ imgSpec.image }.dockerfile]
         }
     }
-}
-
-// Temp fix while LF updates base packer images
-def enableDockerProxy(proxyHost, debug = false) {
-    sh "sudo jq \'. + {\"registry-mirrors\": [\"${proxyHost}\"], debug: ${debug}}\' /etc/docker/daemon.json > /tmp/daemon.json"
-    sh 'sudo mv /tmp/daemon.json /etc/docker/daemon.json'
-    sh 'sudo service docker restart | true'
 }

--- a/vars/edgeXInfraPublish.groovy
+++ b/vars/edgeXInfraPublish.groovy
@@ -40,12 +40,15 @@ def call(body) {
             def insideArgs = getLogPublishContainerArgs()
             // lf-infra-ship-logs
             sh 'facter operatingsystem > ./facter-os'
-            docker.image("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:alpine").inside(insideArgs.join(' ')) {
+            docker.image("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:latest").inside(insideArgs.join(' ')) {
                 sh 'touch /tmp/pre-build-complete' // skips python-tools-install.sh
 
                 // this will remap the sa logs from the host
-                sh 'mkdir -p /var/log/sa'
-                sh 'for file in `ls /var/log/sa-host`; do sadf -c /var/log/sa-host/${file} > /var/log/sa/${file}; done'
+                // Commented out is for alpine based sysstat
+                // sh 'mkdir -p /var/log/sa'
+                // sh 'for file in `ls /var/log/sa-host`; do sadf -c /var/log/sa-host/${file} > /var/log/sa/${file}; done'
+                sh 'mkdir -p /var/log/sysstat'
+                sh 'for file in `ls /var/log/sa-host`; do sadf -c /var/log/sa-host/${file} > /var/log/sysstat/${file}; done'
                 //////////////////////////////////////////////
 
                 try {

--- a/vars/edgeXInfraShipLogs.groovy
+++ b/vars/edgeXInfraShipLogs.groovy
@@ -30,7 +30,7 @@ def call(body) {
 
     // running this inside the lftools container to avoid the 1-3 minute install of lftools
     // Dockerfile for this image can be found here: https://github.com/edgexfoundry/ci-build-images/blob/lftools/Dockerfile.logs-publish
-    docker.image("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:alpine").inside('--privileged -u 0:0 -v /var/log/sa:/var/log/sa-host') {
+    docker.image("${env.DOCKER_REGISTRY}:10003/edgex-lftools-log-publisher:latest").inside('--privileged -u 0:0 -v /var/log/sa:/var/log/sa-host') {
         // A conversion needs to take place for the sysstat files (sar is called during the lftools deploy logs)
         // See: https://serverfault.com/questions/757771/how-to-read-sar-file-from-different-ubuntu-system
 

--- a/vars/edgex.groovy
+++ b/vars/edgex.groovy
@@ -227,3 +227,11 @@ def getGoLangBaseImage(version, alpineBased) {
 
     baseImage
 }
+
+def parallelJobCost(tag='latest') {
+    docker.image("nexus3.edgexfoundry.org:10003/edgex-lftools-log-publisher:${tag}")
+        .inside('-u 0:0 --privileged --net host -v /home/jenkins:/home/jenkins -v /run/cloud-init/result.json:/run/cloud-init/result.json')
+    {
+        lfParallelCostCapture()
+    }
+}


### PR DESCRIPTION
## Summary

I created this PR to mainly tackle an inefficiency around two parts the pipelines:

1. Temporary code to setup a docker proxy. This was only needed for a short time
2. The `lfParallelCostCapture` introduced quite a long delay in the pipeline due to unnecessary python steps

I also updated global-jjb to a new version to make sure the scripts line up https://github.com/lfit/releng-pipelines 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Test Pipelines

Working build ARM stage went from ~3.5 minutes down to 3 secs, x86_64 went from ~40 secs down to 3 seconds

### Before:
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/view/change-requests/job/PR-122/3/consoleFull

**x86_64**
```
18:49:49  ---> job-cost.sh
18:49:49  lf-activate-venv(): INFO: Creating python3 venv at /tmp/venv-te29
18:50:31  lf-activate-venv(): INFO: Adding /tmp/venv-te29/bin to PATH
18:50:31  INFO: No Stack...
18:50:31  INFO: Retrieving Pricing Info for: v3-standard-2
18:50:31  INFO: Archiving Costs
18:50:32  + cat /w/workspace/sample-service/3/archives/cost.csv
18:50:32  + cut -d, -f6
[Pipeline] lock
18:50:33  Trying to acquire lock on [jenkins-edgexfoundry-sample-service-PR-122-3-stack-cost]
18:50:33  Resource [jenkins-edgexfoundry-sample-service-PR-122-3-stack-cost] did not exist. Created.
18:50:33  Lock acquired on [jenkins-edgexfoundry-sample-service-PR-122-3-stack-cost]
[Pipeline] {
[Pipeline] unstash
[Pipeline] sh
18:50:33  + echo total: 0.05999999865889549
```

**arm64**
```
18:52:48  ---> job-cost.sh
18:52:48  lf-activate-venv(): INFO: Creating python3 venv at /tmp/venv-PQgs
18:53:27  lf-activate-venv(): INFO: Installing: zipp==1.1.0 python-openstackclient 
18:54:49  lf-activate-venv(): INFO: Adding /tmp/venv-PQgs/bin to PATH
18:54:49  INFO: No Stack...
18:54:49  INFO: Retrieving Pricing Info for: v2-standard-4
18:54:49  INFO: Archiving Costs
[Pipeline] sh
18:54:49  + cut -d, -f6
18:54:49  + cat /w/workspace/sample-service/3/archives/cost.csv
[Pipeline] lock
18:54:49  Trying to acquire lock on [jenkins-edgexfoundry-sample-service-PR-122-3-stack-cost]
18:54:49  Resource [jenkins-edgexfoundry-sample-service-PR-122-3-stack-cost] did not exist. Created.
18:54:49  Lock acquired on [jenkins-edgexfoundry-sample-service-PR-122-3-stack-cost]
[Pipeline] {
[Pipeline] unstash
[Pipeline] sh
18:54:49  /w/workspace/sample-service/3@tmp/durable-b9c22606/script.sh: 1: /w/workspace/sample-service/3@tmp/durable-b9c22606/script.sh: Syntax error: Unterminated quoted string
[Pipeline] sh
18:54:50  + echo total: 0.18000000715255737
```

### After:
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/PR-124/13/consoleFull

**x86_64**
```
15:35:21  ---> job-cost.sh
15:35:21  lf-activate-venv: SKIPPING
15:35:21  INFO: No Stack...
15:35:22  INFO: Retrieving Pricing Info for: v3-standard-2
15:35:23  INFO: Archiving Costs
[Pipeline] sh
15:35:23  + cut -d, -f6
15:35:23  + cat /w/workspace/sample-service/13/archives/cost.csv
[Pipeline] lock
15:35:23  Trying to acquire lock on [jenkins-edgexfoundry-sample-service-PR-124-13-stack-cost]
15:35:23  Resource [jenkins-edgexfoundry-sample-service-PR-124-13-stack-cost] did not exist. Created.
15:35:23  Lock acquired on [jenkins-edgexfoundry-sample-service-PR-124-13-stack-cost]
[Pipeline] {
[Pipeline] unstash
[Pipeline] sh
15:35:24  + echo total: 0.05999999865889549
````

**arm64**
```
15:37:51  ---> job-cost.sh
15:37:51  lf-activate-venv: SKIPPING
15:37:51  INFO: No Stack...
15:37:52  INFO: Retrieving Pricing Info for: v2-standard-4
15:37:52  INFO: Archiving Costs
[Pipeline] sh
15:37:53  + + cat /w/workspace/sample-service/13/archives/cost.csvcut
15:37:53   -d, -f6
[Pipeline] lock
15:37:53  Trying to acquire lock on [jenkins-edgexfoundry-sample-service-PR-124-13-stack-cost]
15:37:53  Resource [jenkins-edgexfoundry-sample-service-PR-124-13-stack-cost] did not exist. Created.
15:37:53  Lock acquired on [jenkins-edgexfoundry-sample-service-PR-124-13-stack-cost]
[Pipeline] {
[Pipeline] unstash
[Pipeline] sh
15:37:54  /w/workspace/sample-service/13@tmp/durable-03e2d120/script.sh: 1: /w/workspace/sample-service/13@tmp/durable-03e2d120/script.sh: Syntax error: Unterminated quoted string
[Pipeline] sh
15:37:54  + echo total: 0.18000000715255737
```

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
