### PR TITLE
feat: make Dockerfile.build optional

### DIFF
--- a/src/test/groovy/edgeXBuildCAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildCAppSpec.groovy
@@ -25,6 +25,7 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
             edgeXBuildCApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> true
 
         when:
             edgeXBuildCApp.prepBaseBuildImage()
@@ -45,6 +46,7 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
             edgeXBuildCApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> true
 
         when:
             edgeXBuildCApp.prepBaseBuildImage()
@@ -52,6 +54,29 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
             1 * getPipelineMock('docker.build').call([
                     'ci-base-image-arm64',
                     '-f MyDockerBuildFilePath  --build-arg BASE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-gcc-base-arm64:latest --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
+    }
+
+    def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] ARM architecture and base image contains registry and docker build file does not exist" () {
+        setup:
+            def environmentVariables = [
+                'ARCH': 'arm64',
+                'DOCKER_REGISTRY': 'nexus3.edgexfoundry.org',
+                'http_proxy': 'MyHttpProxy',
+                'DOCKER_BASE_IMAGE': 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-gcc-base:latest',
+                'DOCKER_BUILD_FILE_PATH': 'DoesNotExists',
+                'DOCKER_FILE_PATH': 'MyDockerfile',
+                'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext',
+                'DOCKER_BUILD_IMAGE_TARGET': 'MyBuildTarget'
+            ]
+            edgeXBuildCApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> false
+
+        when:
+            edgeXBuildCApp.prepBaseBuildImage()
+        then:
+            1 * getPipelineMock('docker.build').call([
+                    'ci-base-image-arm64',
+                    '-f MyDockerfile  --build-arg BASE=nexus3.edgexfoundry.org:10003/edgex-devops/edgex-gcc-base-arm64:latest --build-arg http_proxy --build-arg https_proxy --build-arg MAKE="echo noop" --target=MyBuildTarget MyDockerBuildContext'])
     }
 
     def "Test validate [Should] raise error [When] config does not include a project parameter" () {
@@ -87,6 +112,7 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_FILE_PATH: 'Dockerfile',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',
+                    DOCKER_BUILD_IMAGE_TARGET: 'builder',
                     DOCKER_IMAGE_NAME: 'device-sdk',
                     DOCKER_REGISTRY_NAMESPACE: '',
                     DOCKER_NEXUS_REPO: 'staging',
@@ -112,6 +138,7 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     dockerFilePath: '/scripts/Dockerfile.alpine-3.9',
                     dockerBuildFilePath: 'Dockerfile.build',
                     dockerBuildContext: '.',
+                    dockerBuildImageTarget: 'MyBuildTarget',
                     dockerBuildArgs: ['MyArg1=Value1', 'MyArg2="Value2"'],
                     dockerNamespace: 'MyDockerNameSpace',
                     dockerImageName: 'MyDockerImageName',
@@ -133,6 +160,7 @@ public class EdgeXBuildCAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_IMAGE_NAME: 'MyDockerImageName',
                     DOCKER_REGISTRY_NAMESPACE: 'MyDockerNameSpace',
                     DOCKER_NEXUS_REPO: 'MyNexusRepo',
+                    DOCKER_BUILD_IMAGE_TARGET: 'MyBuildTarget',
                     BUILD_DOCKER_IMAGE: true,
                     PUSH_DOCKER_IMAGE: true,
                     SEMVER_BUMP_LEVEL: 'patch',

--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -22,12 +22,35 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
             edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> true
         when:
             edgeXBuildGoApp.prepBaseBuildImage()
         then:
              1 * getPipelineMock("docker.build").call([
                     'ci-base-image-MyArch',
                     '-f MyDockerBuildFilePath  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
+    }
+
+    def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] non ARM architecture and docker build file does not exist" () {
+        setup:
+            def environmentVariables = [
+                'ARCH': 'MyArch',
+                'DOCKER_REGISTRY': 'MyDockerRegistry',
+                'http_proxy': 'MyHttpProxy',
+                'DOCKER_BASE_IMAGE': 'MyDockerBaseImage',
+                'DOCKER_BUILD_FILE_PATH': 'DoesNotExists',
+                'DOCKER_FILE_PATH': 'MyDockerfile',
+                'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext',
+                'DOCKER_BUILD_IMAGE_TARGET': 'MyMockTarget'
+            ]
+            edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> false
+        when:
+            edgeXBuildGoApp.prepBaseBuildImage()
+        then:
+             1 * getPipelineMock("docker.build").call([
+                    'ci-base-image-MyArch',
+                    '-f MyDockerfile  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy --build-arg MAKE="echo noop" --target=MyMockTarget MyDockerBuildContext'])
     }
 
     def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] ARM architecture and base image contains registry" () {
@@ -41,6 +64,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
             edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> true
         when:
             edgeXBuildGoApp.prepBaseBuildImage()
         then:
@@ -86,6 +110,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_FILE_PATH: 'Dockerfile',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',
+                    DOCKER_BUILD_IMAGE_TARGET: 'builder',
                     DOCKER_IMAGE_NAME: 'pSoda',
                     DOCKER_REGISTRY_NAMESPACE: '',
                     DOCKER_NEXUS_REPO: 'staging',
@@ -128,6 +153,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     dockerFilePath: 'MyDockerFilePath',
                     dockerBuildFilePath: 'MyDockerBuildFilePath',
                     dockerBuildContext: 'MyDockerBuildContext',
+                    dockerBuildImageTarget: 'MyBuildTarget',
                     dockerBuildArgs: ['MyArg1=Value1', 'MyArg2="Value2"'],
                     dockerNamespace: 'MyDockerNameSpace',
                     dockerImageName: 'MyDockerImageName',
@@ -156,6 +182,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_FILE_PATH: 'MyDockerFilePath',
                     DOCKER_BUILD_FILE_PATH: 'MyDockerBuildFilePath',
                     DOCKER_BUILD_CONTEXT: 'MyDockerBuildContext',
+                    DOCKER_BUILD_IMAGE_TARGET: 'MyBuildTarget',
                     DOCKER_IMAGE_NAME: 'MyDockerImageName',
                     DOCKER_REGISTRY_NAMESPACE: 'MyDockerNameSpace',
                     DOCKER_NEXUS_REPO: 'MyNexusRepo',
@@ -214,6 +241,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_FILE_PATH: 'Dockerfile',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',
+                    DOCKER_BUILD_IMAGE_TARGET: 'builder',
                     DOCKER_IMAGE_NAME: 'pSoda',
                     DOCKER_REGISTRY_NAMESPACE: '',
                     DOCKER_NEXUS_REPO: 'staging',
@@ -270,6 +298,7 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     DOCKER_FILE_PATH: 'Dockerfile',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',
+                    DOCKER_BUILD_IMAGE_TARGET: 'builder',
                     DOCKER_IMAGE_NAME: 'pSoda',
                     DOCKER_REGISTRY_NAMESPACE: '',
                     DOCKER_NEXUS_REPO: 'staging',

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -28,12 +28,35 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
             edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> true
         when:
             edgeXBuildGoParallel.prepBaseBuildImage()
         then:
              1 * getPipelineMock("docker.build").call([
                      'ci-base-image-MyArch',
                      '-f MyDockerBuildFilePath  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
+    }
+
+    def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] non ARM architecture and docker build file does not exist" () {
+        setup:
+            def environmentVariables = [
+                'ARCH': 'MyArch',
+                'DOCKER_REGISTRY': 'MyDockerRegistry',
+                'http_proxy': 'MyHttpProxy',
+                'DOCKER_BASE_IMAGE': 'MyDockerBaseImage',
+                'DOCKER_BUILD_FILE_PATH': 'DoesNotExists',
+                'DOCKER_FILE_PATH': 'MyDockerfile',
+                'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext',
+                'DOCKER_BUILD_IMAGE_TARGET': 'MyMockTarget'
+            ]
+            edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> false
+        when:
+            edgeXBuildGoParallel.prepBaseBuildImage()
+        then:
+             1 * getPipelineMock("docker.build").call([
+                     'ci-base-image-MyArch',
+                     '-f MyDockerfile  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy --build-arg MAKE="echo noop" --target=MyMockTarget MyDockerBuildContext'])
     }
 
     def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] ARM architecture and base image contains registry" () {
@@ -47,6 +70,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext'
             ]
             edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call(_) >> true
         when:
             edgeXBuildGoParallel.prepBaseBuildImage()
         then:
@@ -92,6 +116,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     DOCKER_IMAGE_NAME_SUFFIX: '',
                     DOCKER_BUILD_FILE_PATH: 'Dockerfile.build',
                     DOCKER_BUILD_CONTEXT: '.',
+                    DOCKER_BUILD_IMAGE_TARGET: 'builder',
                     DOCKER_REGISTRY_NAMESPACE: '',
                     DOCKER_NEXUS_REPO: 'staging',
                     BUILD_DOCKER_IMAGE: true,
@@ -124,6 +149,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     dockerImageNameSuffix: 'MySuffix',
                     dockerBuildFilePath: 'MyDockerBuildFilePath',
                     dockerBuildContext: 'MyDockerBuildContext',
+                    dockerBuildImageTarget: 'MyBuildTarget',
                     dockerNamespace: 'MyDockerNameSpace',
                     dockerImageName: 'MyDockerImageName',
                     dockerNexusRepo: 'MyNexusRepo',
@@ -149,6 +175,7 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     DOCKER_IMAGE_NAME_SUFFIX: 'MySuffix',
                     DOCKER_BUILD_FILE_PATH: 'MyDockerBuildFilePath',
                     DOCKER_BUILD_CONTEXT: 'MyDockerBuildContext',
+                    DOCKER_BUILD_IMAGE_TARGET: 'MyBuildTarget',
                     DOCKER_REGISTRY_NAMESPACE: 'MyDockerNameSpace',
                     DOCKER_NEXUS_REPO: 'MyNexusRepo',
                     BUILD_DOCKER_IMAGE: true,

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -40,6 +40,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
  dockerFilePath | optional | str | The path to the Dockerfile for your project.<br /><br />**Default**: `Dockerfile`
  dockerBuildFilePath | optional | str | The path to the Dockerfile that will serve as the CI build image for your project.<br /><br />**Default**: `Dockerfile.build`
  dockerBuildContext | optional | str | The path for Docker to use as its build context when building your project. This applies to building both the CI build image and project image.<br /><br />**Default**: `.`
+ dockerBuildImageTarget | optional | str | The name of the docker multi-stage-build stage the pipeline will use when building the CI build image.<br /><br />**Default**: `builder`
  dockerBuildArgs | optional | list | The list of additonal arguments to pass to Docker when building the image for your project.<br /><br />**Default**: `[]`
  dockerNamespace | optional | str | The docker registry namespace to use when publishing Docker images. **Note** for EdgeX projects images are published to the root of the docker registry and thus the namespace should be empty.<br /><br />**Default**: `''`
  dockerImageName | optional | str | The name of the Docker image for your project.<br /><br />**Default**: `docker-${project}`
@@ -570,12 +571,24 @@ def prepBaseBuildImage() {
         buildArgs << "http_proxy"
         buildArgs << "https_proxy"
     }
-    def buildArgString = buildArgs.join(' --build-arg ')
 
-    docker.build(
-        "ci-base-image-${env.ARCH}",
-        "-f ${env.DOCKER_BUILD_FILE_PATH} ${buildArgString} ${env.DOCKER_BUILD_CONTEXT}"
-    )
+    // If the Dockerfile.build exits? use it
+    if(fileExists(env.DOCKER_BUILD_FILE_PATH)) {
+        def buildArgString = buildArgs.join(' --build-arg ')
+
+        docker.build(
+            "ci-base-image-${env.ARCH}",
+            "-f ${env.DOCKER_BUILD_FILE_PATH} ${buildArgString} ${env.DOCKER_BUILD_CONTEXT}"
+        )
+    } else {
+        buildArgs << 'MAKE="echo noop"'
+        def buildArgString = buildArgs.join(' --build-arg ')
+
+        docker.build(
+            "ci-base-image-${env.ARCH}",
+            "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
+        )
+    }
 }
 
 def buildArtifact() {
@@ -621,6 +634,7 @@ def toEnvironment(config) {
     def _dockerFilePath      = config.dockerFilePath ?: 'Dockerfile'
     def _dockerBuildFilePath = config.dockerBuildFilePath ?: 'Dockerfile.build'
     def _dockerBuildContext  = config.dockerBuildContext ?: '.'
+    def _dockerBuildImageTarget = config.dockerBuildImageTarget ?: 'builder'
     def _dockerBuildArgs     = config.dockerBuildArgs ?: []
     def _dockerNamespace     = config.dockerNamespace ?: '' //default for edgex is empty string
     def _dockerImageName     = config.dockerImageName ?: _projectName.replaceAll('-go', '')
@@ -684,6 +698,7 @@ def toEnvironment(config) {
         DOCKER_FILE_PATH: _dockerFilePath,
         DOCKER_BUILD_FILE_PATH: _dockerBuildFilePath,
         DOCKER_BUILD_CONTEXT: _dockerBuildContext,
+        DOCKER_BUILD_IMAGE_TARGET: _dockerBuildImageTarget,
         DOCKER_IMAGE_NAME: _dockerImageName,
         DOCKER_REGISTRY_NAMESPACE: _dockerNamespace,
         DOCKER_NEXUS_REPO: _dockerNexusRepo,


### PR DESCRIPTION
Make the `Dockerfile.build` file optional in the pipeline. If it exists in the workspace, the code will function as is, if it is not found we will use `--target` option that Docker provides to only build the `builder` stage in the Dockerfile.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#345 

## Sandbox Testing
Test Links :
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fsample-service/detail/PR-125/1/pipeline/169

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
