### PR TITLE
feat: allow retagging of base image when no Dockerfile's exist

### DIFF
--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -26,9 +26,9 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
         when:
             edgeXBuildGoApp.prepBaseBuildImage()
         then:
-             1 * getPipelineMock("docker.build").call([
-                    'ci-base-image-MyArch',
-                    '-f MyDockerBuildFilePath  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
+            1 * getPipelineMock("docker.build").call([
+                   'ci-base-image-MyArch',
+                   '-f MyDockerBuildFilePath  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy MyDockerBuildContext'])
     }
 
     def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] non ARM architecture and docker build file does not exist" () {
@@ -44,13 +44,36 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                 'DOCKER_BUILD_IMAGE_TARGET': 'MyMockTarget'
             ]
             edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('fileExists').call(_) >> false
+            getPipelineMock('fileExists').call('DoesNotExists') >> false
+            getPipelineMock('fileExists').call('MyDockerfile') >> true
         when:
             edgeXBuildGoApp.prepBaseBuildImage()
         then:
-             1 * getPipelineMock("docker.build").call([
-                    'ci-base-image-MyArch',
-                    '-f MyDockerfile  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy --build-arg MAKE="echo noop" --target=MyMockTarget MyDockerBuildContext'])
+            1 * getPipelineMock("docker.build").call([
+                   'ci-base-image-MyArch',
+                   '-f MyDockerfile  --build-arg BASE=MyDockerBaseImage --build-arg http_proxy --build-arg https_proxy --build-arg MAKE="echo noop" --target=MyMockTarget MyDockerBuildContext'])
+    }
+
+    def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] non ARM architecture and docker build file does not exist and dockerfile does not exist" () {
+        setup:
+            def environmentVariables = [
+                'ARCH': 'MyArch',
+                'DOCKER_REGISTRY': 'MyDockerRegistry',
+                'http_proxy': 'MyHttpProxy',
+                'DOCKER_BASE_IMAGE': 'MyDockerBaseImage',
+                'DOCKER_BUILD_FILE_PATH': 'DoesNotExists',
+                'DOCKER_FILE_PATH': 'MyDockerfile',
+                'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext',
+                'DOCKER_BUILD_IMAGE_TARGET': 'MyMockTarget'
+            ]
+            edgeXBuildGoApp.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call('DoesNotExists') >> false
+            getPipelineMock('fileExists').call('MyDockerfile') >> false
+        when:
+            edgeXBuildGoApp.prepBaseBuildImage()
+        then:
+            1 * getPipelineMock('sh').call('docker pull MyDockerBaseImage')
+            1 * getPipelineMock('sh').call('docker tag MyDockerBaseImage ci-base-image-MyArch')
     }
 
     def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] ARM architecture and base image contains registry" () {

--- a/vars/edgeXBuildCApp.groovy
+++ b/vars/edgeXBuildCApp.groovy
@@ -465,13 +465,19 @@ def prepBaseBuildImage() {
             "-f ${env.DOCKER_BUILD_FILE_PATH} ${buildArgString} ${env.DOCKER_BUILD_CONTEXT}"
         )
     } else {
-        buildArgs << 'MAKE="echo noop"'
-        def buildArgString = buildArgs.join(' --build-arg ')
+        if(fileExists(env.DOCKER_FILE_PATH)) {
+            buildArgs << 'MAKE="echo noop"'
+            def buildArgString = buildArgs.join(' --build-arg ')
 
-        docker.build(
-            "ci-base-image-${env.ARCH}",
-            "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
-        )
+            docker.build(
+                "ci-base-image-${env.ARCH}",
+                "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
+            )
+        } else {
+            // just retag the base image if no Dockerfile exists in the repo
+            sh "docker pull ${baseImage}"
+            sh "docker tag ${baseImage} ci-base-image-${env.ARCH}"
+        }
     }
 }
 

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -581,13 +581,19 @@ def prepBaseBuildImage() {
             "-f ${env.DOCKER_BUILD_FILE_PATH} ${buildArgString} ${env.DOCKER_BUILD_CONTEXT}"
         )
     } else {
-        buildArgs << 'MAKE="echo noop"'
-        def buildArgString = buildArgs.join(' --build-arg ')
+        if(fileExists(env.DOCKER_FILE_PATH)) {
+            buildArgs << 'MAKE="echo noop"'
+            def buildArgString = buildArgs.join(' --build-arg ')
 
-        docker.build(
-            "ci-base-image-${env.ARCH}",
-            "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
-        )
+            docker.build(
+                "ci-base-image-${env.ARCH}",
+                "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
+            )
+        } else {
+            // just retag the base image if no Dockerfile exists in the repo
+            sh "docker pull ${baseImage}"
+            sh "docker tag ${baseImage} ci-base-image-${env.ARCH}"
+        }
     }
 }
 

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -503,13 +503,19 @@ def prepBaseBuildImage() {
             "-f ${env.DOCKER_BUILD_FILE_PATH} ${buildArgString} ${env.DOCKER_BUILD_CONTEXT}"
         )
     } else {
-        buildArgs << 'MAKE="echo noop"'
-        def buildArgString = buildArgs.join(' --build-arg ')
+        if(fileExists(env.DOCKER_FILE_PATH)) {
+            buildArgs << 'MAKE="echo noop"'
+            def buildArgString = buildArgs.join(' --build-arg ')
 
-        docker.build(
-            "ci-base-image-${env.ARCH}",
-            "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
-        )
+            docker.build(
+                "ci-base-image-${env.ARCH}",
+                "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
+            )
+        } else {
+            // just retag the base image if no Dockerfile exists in the repo
+            sh "docker pull ${baseImage}"
+            sh "docker tag ${baseImage} ci-base-image-${env.ARCH}"
+        }
     }
 }
 


### PR DESCRIPTION
Add missing use-case for repo's that don't build docker images like, sdk's and go-mods

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/PR-129/3/

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
