### PR TITLE
fix: fix archives directory permissions

### DIFF
--- a/vars/edgeXInfraPublish.groovy
+++ b/vars/edgeXInfraPublish.groovy
@@ -30,6 +30,10 @@ def call(body) {
     def _dockerOptimized = edgex.defaultTrue(config.dockerOptimized)
 
     stage('LF Post Build Actions') {
+        sh 'ls -al $WORKSPACE/archives'
+        sh 'sudo chown -R jenkins:jenkins $WORKSPACE/archives'
+        sh 'ls -al $WORKSPACE/archives'
+
         // lf-infra-systat
         sh(script: libraryResource('global-jjb-shell/sysstat.sh'))
 


### PR DESCRIPTION
This bug was introduced when I made the change to dockerize the job cost code a few weeks ago.

Here is a test job where it was failing before and is fixed after:

Before:
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fci-build-images/detail/PR-173/3/pipeline

After:
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fci-build-images/detail/PR-174/1/pipeline/

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links : 

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
