### PR TITLE
fix: add check to make sure archives directory exists

### DIFF
--- a/vars/edgeXInfraPublish.groovy
+++ b/vars/edgeXInfraPublish.groovy
@@ -30,9 +30,13 @@ def call(body) {
     def _dockerOptimized = edgex.defaultTrue(config.dockerOptimized)
 
     stage('LF Post Build Actions') {
-        sh 'ls -al $WORKSPACE/archives'
-        sh 'sudo chown -R jenkins:jenkins $WORKSPACE/archives'
-        sh 'ls -al $WORKSPACE/archives'
+        sh '''
+        if [ -d "$WORKSPACE/archives" ]; then
+            ls -al "$WORKSPACE/archives"
+            sudo chown -R jenkins:jenkins "$WORKSPACE/archives"
+            ls -al "$WORKSPACE/archives"
+        fi
+        '''
 
         // lf-infra-systat
         sh(script: libraryResource('global-jjb-shell/sysstat.sh'))


### PR DESCRIPTION
Sometimes builds do not have an `archives` directory. This fix checks to make sure it does.

Sample service build
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/view/change-requests/job/PR-130/1/consoleFull

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
