### PR TITLE
fix: build inline image with go modules downloaded

### DIFF
--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -75,11 +75,12 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
             edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
             getPipelineMock('fileExists').call('DoesNotExists') >> false
             getPipelineMock('fileExists').call('MyDockerfile') >> false
+            getPipelineMock('fileExists').call('go.mod') >> true
         when:
             edgeXBuildGoParallel.prepBaseBuildImage()
         then:
             1 * getPipelineMock('sh').call('docker pull MyDockerBaseImage')
-            1 * getPipelineMock('sh').call('docker tag MyDockerBaseImage ci-base-image-MyArch')
+            1 * getPipelineMock('sh').call('echo "FROM MyDockerBaseImage\nWORKDIR /edgex\nCOPY go.mod .\nRUN go mod download" | docker build -t ci-base-image-MyArch -f - .')
     }
 
     def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] non ARM architecture and docker build file does not exist and dockerfile" () {
@@ -96,6 +97,29 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
             edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
             getPipelineMock('fileExists').call('DoesNotExists') >> false
             getPipelineMock('fileExists').call(null) >> false
+            getPipelineMock('fileExists').call('go.mod') >> true
+        when:
+            edgeXBuildGoParallel.prepBaseBuildImage()
+        then:
+            1 * getPipelineMock('sh').call('docker pull MyDockerBaseImage')
+            1 * getPipelineMock('sh').call('echo "FROM MyDockerBaseImage\nWORKDIR /edgex\nCOPY go.mod .\nRUN go mod download" | docker build -t ci-base-image-MyArch -f - .')
+    }
+
+    def "Test prepBaseBuildImage [Should] call docker build with expected arguments [When] non ARM architecture and docker build file does not exist and dockerfile and go.mod does not exist" () {
+        setup:
+            def environmentVariables = [
+                'ARCH': 'MyArch',
+                'DOCKER_REGISTRY': 'MyDockerRegistry',
+                'http_proxy': 'MyHttpProxy',
+                'DOCKER_BASE_IMAGE': 'MyDockerBaseImage',
+                'DOCKER_BUILD_FILE_PATH': 'DoesNotExists',
+                'DOCKER_BUILD_CONTEXT': 'MyDockerBuildContext',
+                'DOCKER_BUILD_IMAGE_TARGET': 'MyMockTarget'
+            ]
+            edgeXBuildGoParallel.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('fileExists').call('DoesNotExists') >> false
+            getPipelineMock('fileExists').call(null) >> false
+            getPipelineMock('fileExists').call('go.mod') >> false
         when:
             edgeXBuildGoParallel.prepBaseBuildImage()
         then:

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -512,9 +512,15 @@ def prepBaseBuildImage() {
                 "-f ${env.DOCKER_FILE_PATH} ${buildArgString} --target=${env.DOCKER_BUILD_IMAGE_TARGET} ${env.DOCKER_BUILD_CONTEXT}"
             )
         } else {
-            // just retag the base image if no Dockerfile exists in the repo
             sh "docker pull ${baseImage}"
-            sh "docker tag ${baseImage} ci-base-image-${env.ARCH}"
+
+            // This will build a new ci-base-image with all the Go modules enabled.
+            // This could externalized to another file, but for now due to simplicity, I am doing the build inline
+            if(fileExists('go.mod')) {
+                sh "echo \"FROM ${baseImage}\nWORKDIR /edgex\nCOPY go.mod .\nRUN go mod download\" | docker build -t ci-base-image-${env.ARCH} -f - ."
+            } else {
+                sh "docker tag ${baseImage} ci-base-image-${env.ARCH}"
+            }
         }
     }
 }


### PR DESCRIPTION
This fix really only applies to edgeXBuildGoParallel and instead of just pulling and retagging will create a new image specifically with `go mod download` being called. This will pre-download all the dependencies and allow to keep performance gains. Doing it inline for now to keep the footprint small.

Tested with edgex-go: https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fedgex-go/detail/PR-3651/4/pipeline/128

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
