### PR TITLE
ci: check if go.sum does not exist before running go mod tidy

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -245,7 +245,7 @@ def call(config) {
                                 steps {
                                     script {
                                         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
-                                            if(env.GO_VERSION =~ '1.16') {
+                                            if(!fileExists('go.sum') && env.GO_VERSION =~ '1.16') {
                                                 sh 'go mod tidy' // for Go 1.16
                                             }
                                             sh "${env.TEST_SCRIPT}"
@@ -348,7 +348,7 @@ def call(config) {
                                 steps {
                                     script {
                                         docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
-                                            if(env.GO_VERSION =~ '1.16') {
+                                            if(!fileExists('go.sum') && env.GO_VERSION =~ '1.16') {
                                                 sh 'go mod tidy' // for Go 1.16
                                             }
                                             sh "${env.TEST_SCRIPT}"

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -459,7 +459,7 @@ def testAndVerify(codeCov = true) {
     edgex.bannerMessage "[edgeXBuildGoParallel] Running Tests and Build..."
 
     // make test raml_verify
-    if(env.GO_VERSION =~ '1.16') {
+    if(!fileExists('go.sum') && env.GO_VERSION =~ '1.16') {
         sh 'go mod tidy' // for Go 1.16
     }
     sh env.TEST_SCRIPT


### PR DESCRIPTION
After today's DevOps WG meeting, it was decided that the go.sum would start being commited back into the repo. Due to this, `go mod tidy` is no longer required to be called. So this change will only run `go mod tidy` if `go.sum` does not exist and we are at `Go 1.16`

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
