### PR TITLE
feat: use Python-base git-semver capability

### DIFF
--- a/src/test/groovy/edgeXReleaseGitTagSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagSpec.groovy
@@ -68,7 +68,7 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
             edgeXReleaseGitTag.setAndSignGitTag('sample-service', '1.2.3')
         then:
             1 * getPipelineMock('edgeXSemver.call')('init', '1.2.3')
-            1 * getPipelineMock('edgeXSemver.call')('tag -force')
+            1 * getPipelineMock('edgeXSemver.call')('tag --force')
             1 * getPipelineMock('dir').call(_) >> { _arguments ->
                 assert 'sample-service' == _arguments[0][0]
             }
@@ -81,8 +81,8 @@ public class EdgeXReleaseGitTagSpec extends JenkinsPipelineSpecification {
         when:
             edgeXReleaseGitTag.setAndSignGitTag('sample-service', '1.2.3')
         then:
-            1 * getPipelineMock('echo').call("edgeXSemver init 1.2.3")
-            1 * getPipelineMock('echo').call("edgeXSemver tag -force")
+            1 * getPipelineMock('echo').call("edgeXSemver init --version=1.2.3")
+            1 * getPipelineMock('echo').call("edgeXSemver tag --force")
             1 * getPipelineMock('edgeXReleaseGitTagUtil.signGitTag').call('1.2.3', 'sample-service')
     }
 

--- a/src/test/groovy/edgeXReleaseGitTagUtilSpec.groovy
+++ b/src/test/groovy/edgeXReleaseGitTagUtilSpec.groovy
@@ -127,7 +127,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
                 assert _arguments[0][0][0] == 'SEMVER_BRANCH=main'
             }
             1 * getPipelineMock('edgeXReleaseGitTag.setAndSignGitTag').call('sample-service', '1.2.3')
-            1 * getPipelineMock('edgeXReleaseGitTag.bumpAndPushGitTag').call('sample-service', '1.2.3', '-pre=dev pre', true)
+            1 * getPipelineMock('edgeXReleaseGitTag.bumpAndPushGitTag').call('sample-service', '1.2.3', 'pre --prefix=dev', true)
     }
 
     def "Test releaseGitTag [Should] call expected [When] called with LTS true" () {
@@ -149,7 +149,7 @@ public class EdgeXReleaseGitTagUtilSpec extends JenkinsPipelineSpecification {
                 assert _arguments[0][0][0] == 'SEMVER_BRANCH=jakarta'
             }
             1 * getPipelineMock('edgeXReleaseGitTag.setAndSignGitTag').call('sample-service', '1.2.3')
-            1 * getPipelineMock('edgeXReleaseGitTag.bumpAndPushGitTag').call('sample-service', '1.2.3', '-pre=dev pre', true)
+            1 * getPipelineMock('edgeXReleaseGitTag.bumpAndPushGitTag').call('sample-service', '1.2.3', 'pre --prefix=dev', true)
     }
 
 }

--- a/src/test/groovy/edgeXSemverSpec.groovy
+++ b/src/test/groovy/edgeXSemverSpec.groovy
@@ -17,7 +17,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSemver()
         then:
-            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             1 * getPipelineMock('sh')([script: 'git semver', returnStdout: true]) >> '1.2.3-dev.4\n'
             environmentVariables['VERSION'] == '1.2.3-dev.4'
     }
@@ -26,7 +26,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')([script: 'git semver', returnStdout: true]) >> '1.2.3-dev.4\n'
         expect:
             def result = edgeXSemver()
@@ -43,7 +43,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
             edgeXSemver('init', '1.2.4')
         then:
             // verify docker.image
-            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
+            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable('DockerImageMock')
             // verify docker.image.inside arguments
             1 * getPipelineMock('DockerImageMock.inside').call(_) >> { _arguments ->
                 def dockerArgs = '-u 0:0 -v /etc/ssh:/etc/ssh'
@@ -58,7 +58,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
                 assert envArgs == _arguments[0][0]
             }
             // verify git semver command
-            1 * getPipelineMock('sh').call('git semver init -ver=1.2.4 -force')
+            1 * getPipelineMock('sh').call('git semver init --version=1.2.4 --force')
             environmentVariables['VERSION'] == '1.2.4'
             // verify writefile
             1 * getPipelineMock('writeFile').call([file: 'VERSION', text: '1.2.4'])
@@ -77,7 +77,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         when:
             edgeXSemver('init')
         then:
-            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            1 * getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
 
             1 * getPipelineMock('echo')("[edgeXSemver]: GITSEMVER_HEAD_TAG is already set to 'MyTag'")
 
@@ -92,7 +92,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> 'v1.2.3'
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
@@ -109,7 +109,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> ''
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
@@ -126,12 +126,12 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> 'v2.3.4\nstable'
         when:
             edgeXSemver('init', '2.3.4')
         then:
-            1 * getPipelineMock('sh').call('git semver init -ver=2.3.4 -force')
+            1 * getPipelineMock('sh').call('git semver init --version=2.3.4 --force')
             environmentVariables['GITSEMVER_HEAD_TAG'] == 'v2.3.4|stable'
             environmentVariables['VERSION'] == '2.3.4'
             environmentVariables['GITSEMVER_INIT_VERSION'] == '2.3.4'
@@ -142,12 +142,12 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> ''
         when:
             edgeXSemver('init', '2.3.4')
         then:
-            1 * getPipelineMock('sh').call('git semver init -ver=2.3.4 -force')
+            1 * getPipelineMock('sh').call('git semver init --version=2.3.4 --force')
             environmentVariables.containsKey('GITSEMVER_HEAD_TAG') == false
             environmentVariables['VERSION'] == '2.3.4'
             environmentVariables['GITSEMVER_INIT_VERSION'] == '2.3.4'
@@ -158,12 +158,12 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> 'v2.3.4-dev.13'
         when:
             edgeXSemver('init', '2.3.4')
         then:
-            1 * getPipelineMock('sh').call('git semver init -ver=2.3.4 -force')
+            1 * getPipelineMock('sh').call('git semver init --version=2.3.4 --force')
             environmentVariables.containsKey('GITSEMVER_HEAD_TAG') == false
             environmentVariables['VERSION'] == '2.3.4'
             environmentVariables['GITSEMVER_INIT_VERSION'] == '2.3.4'
@@ -174,14 +174,14 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
             // TODO: I'm not convinced this should be supported - specify semverVersion if specific version is to be specified
-            edgeXSemver('init -ver=2.3.4 -force')
+            edgeXSemver('init --version=2.3.4 --force')
         then:
             0 * getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true)
-            1 * getPipelineMock('sh').call('git semver init -ver=2.3.4 -force')
+            1 * getPipelineMock('sh').call('git semver init --version=2.3.4 --force')
             environmentVariables.containsKey('GITSEMVER_HEAD_TAG') == false
             environmentVariables['VERSION'] == '1.2.4-dev.1'
             1 * getPipelineMock('sh').call('sudo chown -R jenkins:jenkins .semver')
@@ -193,7 +193,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
                 'GITSEMVER_HEAD_TAG': '1.2.3'
             ]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
             edgeXSemver('tag')
@@ -208,7 +208,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> ''
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
@@ -225,15 +225,15 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
                 'GITSEMVER_INIT_VERSION': '1.2.3'
             ]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git tag --points-at HEAD', returnStdout: true) >> ''
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.3'
         when:
-            edgeXSemver('tag -force')
+            edgeXSemver('tag --force')
         then:
             0 * getPipelineMock('echo')("[edgeXSemver]: HEAD is already tagged with v1.2.3")
             1 * getPipelineMock('echo')("[edgeXSemver]: removing remote and local tags for v1.2.3")
-            1 * getPipelineMock('sh').call('git semver tag -force')
+            1 * getPipelineMock('sh').call('git semver tag --force')
             environmentVariables['VERSION'] == '1.2.3'
             0 * getPipelineMock('sh').call('sudo chown -R jenkins:jenkins .semver')
     }
@@ -242,7 +242,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
             edgeXSemver('bump pre')
@@ -258,7 +258,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
                 'GITSEMVER_HEAD_TAG': '1.2.4-dev.1'
             ]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
             edgeXSemver('bump pre')
@@ -273,7 +273,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
         setup:
             def environmentVariables = [:]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
             edgeXSemver('push')
@@ -289,7 +289,7 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
                 'GITSEMVER_HEAD_TAG': '1.2.4-dev.1'
             ]
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
-            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:latest') >> explicitlyMockPipelineVariable()
+            getPipelineMock('docker.image')('nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:latest') >> explicitlyMockPipelineVariable()
             getPipelineMock('sh')(script: 'git semver', returnStdout: true) >> '1.2.4-dev.1'
         when:
             edgeXSemver('push')
@@ -319,12 +319,12 @@ public class EdgeXSemverSpec extends JenkinsPipelineSpecification {
             edgeXSemver.getBinding().setVariable('env', environmentVariables)
             getPipelineMock('sh')([script:'git tag --points-at HEAD', returnStdout:true]) >> ''
         when:
-            edgeXSemver.executeGitSemver('MyCredentials', 'git semver tag -force')
+            edgeXSemver.executeGitSemver('MyCredentials', 'git semver tag --force')
         then:
             // ugly to assert due to spaces after carriage returns
             // 1 * getPipelineMock('sh').call('set +x\nset +e\ngit push origin :refs/tags/v1.2.3\ngit tag -d v1.2.3\nset -e\n')
             1 * getPipelineMock('echo').call("[edgeXSemver]: removing remote and local tags for v1.2.3")
-            1 * getPipelineMock('sh').call('git semver tag -force')
+            1 * getPipelineMock('sh').call('git semver tag --force')
     }
 
     def "Test setGitSemverHeadTag [Should] not call sshagent [When] GITSEMVER_HEAD_TAG is set" () {

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -479,7 +479,7 @@ def call(config) {
                                         def tagCommand = 'tag'
                                         def _commitMsg = edgex.getCommitMessage(env.GIT_COMMIT)
                                         if(edgex.isBuildCommit(_commitMsg)) {
-                                            tagCommand = 'tag -force'
+                                            tagCommand = 'tag --force'
                                         }
 
                                         edgeXSemver "${tagCommand}"

--- a/vars/edgeXReleaseGitTag.groovy
+++ b/vars/edgeXReleaseGitTag.groovy
@@ -64,13 +64,13 @@ def setAndSignGitTag(name, version) {
     // call edgeXSemver functions to force tag version and push
     println "[edgeXReleaseGitTag]: setting tag for ${name} to: ${version} - DRY_RUN: ${env.DRY_RUN}"
     if(edgex.isDryRun()) {
-        echo("edgeXSemver init ${version}")
-        echo("edgeXSemver tag -force")
+        echo("edgeXSemver init --version=${version}")
+        echo("edgeXSemver tag --force")
     }
     else {
         dir("${name}") {
             edgeXSemver('init', version)
-            edgeXSemver('tag -force')
+            edgeXSemver('tag --force')
         }
     }
     edgeXReleaseGitTagUtil.signGitTag(version, name)

--- a/vars/edgeXReleaseGitTagUtil.groovy
+++ b/vars/edgeXReleaseGitTagUtil.groovy
@@ -79,7 +79,7 @@ def releaseGitTag(releaseInfo, credentials, bump = true, tag = true) {
             if (tag){
                 edgeXReleaseGitTag.setAndSignGitTag(releaseInfo.name, releaseInfo.version)
             }
-            def semverBumpLevel = releaseInfo.semverBumpLevel ?: '-pre=dev pre'
+            def semverBumpLevel = releaseInfo.semverBumpLevel ?: 'pre --prefix=dev'
             edgeXReleaseGitTag.bumpAndPushGitTag(releaseInfo.name, releaseInfo.version, semverBumpLevel, bump)
         }
     }

--- a/vars/edgeXSemver.groovy
+++ b/vars/edgeXSemver.groovy
@@ -16,8 +16,8 @@
 
 def call(command = null, semverVersion = '', gitSemverVersion = 'latest', credentials = 'edgex-jenkins-ssh') {
     def semverImage = env.ARCH && env.ARCH == 'arm64'
-        ? "nexus3.edgexfoundry.org:10004/edgex-devops/git-semver-arm64:${gitSemverVersion}"
-        : "nexus3.edgexfoundry.org:10004/edgex-devops/git-semver:${gitSemverVersion}"
+        ? "nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver-arm64:${gitSemverVersion}"
+        : "nexus3.edgexfoundry.org:10003/edgex-devops/py-git-semver:${gitSemverVersion}"
 
     def envVars = [
         'SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts',
@@ -38,8 +38,8 @@ def call(command = null, semverVersion = '', gitSemverVersion = 'latest', creden
 
         // If semverVersion is passed in override the version from the .semver directory
         if (command == 'init' && semverVersion) {
-            semverCommand << "-ver=${semverVersion}"
-            semverCommand << "-force"
+            semverCommand << "--version=${semverVersion}"
+            semverCommand << "--force"
         }
 
         setupKnownHosts()


### PR DESCRIPTION
Update to leverage Python-based `git-semver` capability: [User Story 3314](https://dev.azure.com/brokenbluesky/IOTG%20RBHE/_workitems/edit/3314)

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Integration Testing
Build Pipeline using edgeXBuildGoApp
[Build Pipeline #37](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/main/37/)
[Build Pipeline #38](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/main/38/)
Build Pipeline using explicit edgeXSemver:
[Build Pipeline #39](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/main/39/)
Build Pipeline using edgeXBuildGoApp
[Build Pipeline #40](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/main/40/)
Release Pipeline
[Release PR-230](https://github.com/edgexfoundry/cd-management/pull/230)
[cd-management build for PR-230 #4](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/view/change-requests/job/PR-230/4/)
[sample-service Build Pipeline #41](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/sample-service/job/main/41/)

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
