### PR TITLE
feat: Snyk enhancements for projectName and debug

### DIFF
--- a/src/test/groovy/edgeXBuildGoAppSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoAppSpec.groovy
@@ -210,7 +210,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     publishSwaggerDocs: true,
                     swaggerApiFolders: ['api/v20', 'api/v30'],
                     artifactTypes: ['docker'],
-                    failureNotify: 'mock@lists.edgexfoundry.org'
+                    failureNotify: 'mock@lists.edgexfoundry.org',
+                    snykDebug: true
                 ]
             ]
             expectedResult << [
@@ -243,7 +244,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: "archives/bin",
                     ARTIFACT_TYPES: 'docker',
                     SHOULD_BUILD: true,
-                    BUILD_FAILURE_NOTIFY_LIST: 'mock@lists.edgexfoundry.org'
+                    BUILD_FAILURE_NOTIFY_LIST: 'mock@lists.edgexfoundry.org',
+                    SNYK_DEBUG: true
                 ]
             ]
     }
@@ -300,7 +302,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_TYPES: 'archive',
                     SHOULD_BUILD: true,
                     ARCHIVE_ARTIFACTS: '**/*.tar.gz **/*.zip',
-                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org',
+                    SNYK_DEBUG: false
                 ]
             ]
     }
@@ -355,7 +358,8 @@ public class EdgeXBuildGoAppSpec extends JenkinsPipelineSpecification {
                     ARTIFACT_ROOT: 'archives/bin',
                     ARTIFACT_TYPES: 'foo',
                     SHOULD_BUILD: false,
-                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org',
+                    SNYK_DEBUG: false
                 ]
             ]
     }

--- a/src/test/groovy/edgeXBuildGoParallelSpec.groovy
+++ b/src/test/groovy/edgeXBuildGoParallelSpec.groovy
@@ -249,7 +249,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'openapi/v1 openapi/v2',
                     // SNAP_CHANNEL: 'latest/edge',
                     BUILD_SNAP: false,
-                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
+                    BUILD_FAILURE_NOTIFY_LIST: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org',
+                    SNYK_DEBUG: false
                 ]
             ]
     }
@@ -280,7 +281,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     useAlpineBase: false,
                     publishSwaggerDocs: true,
                     swaggerApiFolders: ['api/v20', 'api/v30'],
-                    failureNotify: 'mock@lists.edgexfoundry.org'
+                    failureNotify: 'mock@lists.edgexfoundry.org',
+                    snykDebug: true
                 ]
             ]
             expectedResult << [
@@ -308,7 +310,8 @@ public class EdgeXBuildGoParallelSpec extends JenkinsPipelineSpecification {
                     SWAGGER_API_FOLDERS: 'api/v20 api/v30',
                     // SNAP_CHANNEL: 'edge',
                     BUILD_SNAP: false,
-                    BUILD_FAILURE_NOTIFY_LIST: 'mock@lists.edgexfoundry.org'
+                    BUILD_FAILURE_NOTIFY_LIST: 'mock@lists.edgexfoundry.org',
+                    SNYK_DEBUG: true
                 ]
             ]
     }

--- a/src/test/groovy/edgeXSnykSpec.groovy
+++ b/src/test/groovy/edgeXSnykSpec.groovy
@@ -40,6 +40,41 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
             1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk monitor --org=MySnykOrg', returnStatus: true])
     }
 
+    def "Test edgeXSnyk [Should] call snyk monitor with options [When] called with no arguments when SNYK_DEBUG is true" () {
+        setup:
+            def environmentVariables = [
+                'SNYK_DEBUG': 'true'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk()
+        then:
+            1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk monitor --org=edgex-jenkins -d', returnStatus: true])
+    }
+
+    def "Test edgeXSnyk [Should] call snyk monitor without options [When] called with no arguments when SNYK_DEBUG is false" () {
+        setup:
+            def environmentVariables = [
+                'SNYK_DEBUG': 'false'
+            ]
+            edgeXSnyk.getBinding().setVariable('env', environmentVariables)
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk()
+        then:
+            1 * getPipelineMock("sh").call([script: 'set -o pipefail ; snyk monitor --org=edgex-jenkins', returnStatus: true])
+    }
+
+    def "Test edgeXSnyk [Should] call snyk monitor with options [When] called with projectName argument" () {
+        setup:
+            getPipelineMock('docker.image')(snykImage) >> explicitlyMockPipelineVariable('DockerImageMock')
+        when:
+            edgeXSnyk(projectName: 'mock-project')
+        then:
+            1 * getPipelineMock("sh").call([script: "set -o pipefail ; snyk monitor --org=edgex-jenkins --project-name='mock-project'", returnStatus: true])
+    }
+
     // Docker image tests
 
     def "Test edgeXSnyk [Should] provide the expected arguments to the snyk docker image [When] called" () {
@@ -94,7 +129,7 @@ public class EdgeXSnykSpec extends JenkinsPipelineSpecification {
             }
             getPipelineMock('readFile').call(file: './snykResults.log') >> 'MockSnykLog'
 
-            def messageBody = '''Possible vulnerablities have been found by Snyk in for the following build: MyMockJob
+            def messageBody = '''Possible vulnerabilities have been found by Snyk in for the following build: MyMockJob
 More details can be found here:
 ===============================================
 Build URL: MockBuildUrl/

--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -431,7 +431,7 @@ def call(config) {
                     stage('Snyk Dependency Scan') {
                         when { expression { edgex.isReleaseStream() } }
                         steps {
-                            edgeXSnyk()
+                            edgeXSnyk(projectName: "edgexfoundry/${env.PROJECT}:${env.GIT_BRANCH}")
                         }
                     }
 
@@ -651,9 +651,11 @@ def toEnvironment(config) {
     def _publishSwaggerDocs  = edgex.defaultFalse(config.publishSwaggerDocs)
     def _swaggerApiFolders   = config.swaggerApiFolders ?: ['openapi/v1']
     def _failureNotify       = config.failureNotify ?: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
+    def _snykDebug            = edgex.defaultFalse(config.snykDebug)
 
     def _buildExperimentalDockerImage  = edgex.defaultFalse(config.buildExperimentalDockerImage)
     def _buildStableDockerImage        = false
+
 
     def _artifactTypes = config.artifactTypes ?: ['docker']
 
@@ -717,7 +719,8 @@ def toEnvironment(config) {
         ARTIFACT_ROOT: _artifactRoot,
         ARTIFACT_TYPES: _artifactTypes.join(' '),
         SHOULD_BUILD: _shouldBuild,
-        BUILD_FAILURE_NOTIFY_LIST: _failureNotify
+        BUILD_FAILURE_NOTIFY_LIST: _failureNotify,
+        SNYK_DEBUG: _snykDebug
     ]
 
     // encode with comma in case build arg has space

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -401,7 +401,7 @@ def call(config) {
                     stage('Snyk Scan') {
                         when { expression { edgex.isReleaseStream() } }
                         steps {
-                            edgeXSnyk()
+                            edgeXSnyk(projectName: "edgexfoundry/${env.PROJECT}:${env.GIT_BRANCH}")
                         }
                     }
 
@@ -575,6 +575,7 @@ def toEnvironment(config) {
     def _publishSwaggerDocs    = edgex.defaultFalse(config.publishSwaggerDocs)
     def _swaggerApiFolders     = config.swaggerApiFolders ?: ['openapi/v1', 'openapi/v2']
     def _failureNotify         = config.failureNotify ?: 'edgex-tsc-core@lists.edgexfoundry.org,edgex-tsc-devops@lists.edgexfoundry.org'
+    def _snykDebug             = edgex.defaultFalse(config.snykDebug)
 
     // def _snapChannel           = config.snapChannel ?: 'latest/edge'
     def _buildSnap             = edgex.defaultFalse(config.buildSnap)
@@ -608,7 +609,8 @@ def toEnvironment(config) {
         SWAGGER_API_FOLDERS: _swaggerApiFolders.join(' '),
         // SNAP_CHANNEL: _snapChannel,
         BUILD_SNAP: _buildSnap,
-        BUILD_FAILURE_NOTIFY_LIST: _failureNotify
+        BUILD_FAILURE_NOTIFY_LIST: _failureNotify,
+        SNYK_DEBUG: _snykDebug
     ]
 
     edgex.bannerMessage "[edgeXBuildGoParallel] Pipeline Parameters:"

--- a/vars/edgeXSnyk.groovy
+++ b/vars/edgeXSnyk.groovy
@@ -77,6 +77,7 @@ def call(config = [:]) {
     def sendEmail         = edgex.defaultTrue(config.sendEmail)
     def snykRecipients    = config.emailTo
     def htmlReport        = edgex.defaultFalse(config.htmlReport)
+    def projectName       = config.projectName
 
     def snykScannerImage  = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-snyk-go:1.410.4'
     def org               = env.SNYK_ORG ?: 'edgex-jenkins'
@@ -85,6 +86,14 @@ def call(config = [:]) {
 
     // Run snyk monitor by default
     def command = ['snyk', snykCmd, "--org=${org}"]
+
+    if(projectName) {
+        command << "--project-name='${projectName}'"
+    }
+
+    if(env.SNYK_DEBUG != null && env.SNYK_DEBUG == 'true') {
+        command << '-d'
+    }
 
     println "[edgeXSnyk] dockerImage=${dockerImage}, dockerFile=${dockerFile}"
 
@@ -153,7 +162,7 @@ def call(config = [:]) {
 
                     mail body: messageBody, subject: subject, to: snykRecipients, mimeType: 'text/html'
                 } else {
-                    def messageBody = """Possible vulnerablities have been found by Snyk in for the following build: ${env.JOB_NAME}
+                    def messageBody = """Possible vulnerabilities have been found by Snyk in for the following build: ${env.JOB_NAME}
 More details can be found here:
 ===============================================
 Build URL: ${env.BUILD_URL}
@@ -174,7 +183,7 @@ ${readFile(file: './snykResults.log')}
                 }
             }
 
-            unstable(message: 'Snyk Found Vulnerabilites')
+            unstable(message: 'Snyk Found Vulnerabilities')
         }
         // 2 and up
         else {


### PR DESCRIPTION
This new features allows for:

- Custom snyk project name to be used to help create unique branch level projects in Snyk (this is needed to distinguish the main from jakarta cli projects)
- Snyk Debug config param to allow more insight into Snyk cli failures

Functional Test Job:
https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fsample-service/detail/main/65/pipeline/615

The project also shows up correctly on the Snyk side.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
