### PR TITLE
feat: add new functionality to bump version after release

### DIFF
--- a/src/test/groovy/edgeXReleaseDocsSpec.groovy
+++ b/src/test/groovy/edgeXReleaseDocsSpec.groovy
@@ -144,6 +144,7 @@ public class EdgeXReleaseDocsSpec extends JenkinsPipelineSpecification {
             1 * getPipelineMock('sh').call('git reset --hard c0818f6da75fef2ffe509345f5fc87075bcd5114')
             1 * getPipelineMock('sh').call('git checkout -b currentRelease-version-changes')
             1 * getPipelineMock('sh').call("sed -E -i 's|replace\\(\".*\"\\)|replace\\(\"2.2\"\\)|g' docs/index.html")
+            1 * getPipelineMock('sh').call("sed -i 's|2.2|2.3|g' mkdocs.yml")
 
             1 * getPipelineMock('writeFile').call(['file': 'docs/versions.json',  'text':'\n[ {     "version": "2.0",     "title": "2.0-Ireland",     "aliases": [] }, {     "version": "2.1",     "title": "2.1-Jakarta",     "aliases": [] }, {     "version": "2.2",     "title": "2.2-Kamakura",     "aliases": [] }, {     "version": "2.3",     "title": "2.3-NextRelease",     "aliases": [] }\n]\n'])
 

--- a/vars/edgeXReleaseDocs.groovy
+++ b/vars/edgeXReleaseDocs.groovy
@@ -143,6 +143,10 @@ def publishVersionChangesPR(releaseInfo) {
 
     writeFile(file: 'docs/versions.json', text: newVersionJson)
 
+    println("[edgeXReleaseDocs] Updating release version mkdocs.yml")
+
+    sh "sed -i 's|${currentVersion}|${nextVersion}|g' mkdocs.yml"
+
     edgex.bannerMessage "[edgeXReleaseDocs] Here is the diff related to the version changes"
     sh 'git diff'
 


### PR DESCRIPTION
This change bumps the version in mkdocs.yml, to be set for the next release (usually a manual activity done after the release). This will create a diff that looks like this:

```diff
diff --git i/mkdocs.yml w/mkdocs.yml
index 564219be..6690a360 100644
--- i/mkdocs.yml
+++ w/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: EdgeX Foundry Documentation
 docs_dir: ./docs_src
-site_dir: ./docs/2.2
+site_dir: ./docs/2.3
 site_description: 'Documentation for use of EdgeX Foundry'
 site_author: 'Michael Johanson'
 site_url: 'https://edgexfoundry.github.io/edgex-docs/'
```
Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
