### PR TITLE
ci: add privileged to fix issues with Go 1.18 and AppArmor

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -225,7 +225,10 @@ def call(config) {
                                         // }
                                         steps {
                                             script {
-                                                docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
+                                                docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0 --privileged') {
+                                                    // fixes permissions issues due new Go 1.18 buildvcs checks
+                                                    sh 'git config --global --add safe.directory $WORKSPACE'
+                                                    
                                                     // TODO: This should go away after Kamakura, all repos now have a go.sum file.
                                                     if(!fileExists('go.sum') && env.GO_VERSION =~ '1.16') {
                                                         sh 'go mod tidy' // for Go 1.16
@@ -336,7 +339,10 @@ def call(config) {
                                         // }
                                         steps {
                                             script {
-                                                docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0') {
+                                                docker.image("ci-base-image-${env.ARCH}").inside('-u 0:0 --privileged') {
+                                                    // fixes permissions issues due new Go 1.18 buildvcs checks
+                                                    sh 'git config --global --add safe.directory $WORKSPACE'
+
                                                     // TODO: This should go away after Kamakura, all repos now have a go.sum file.
                                                     if(!fileExists('go.sum') && env.GO_VERSION =~ '1.16') {
                                                         sh 'go mod tidy' // for Go 1.16

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -468,6 +468,9 @@ def call(config) {
 def testAndVerify(codeCov = true) {
     edgex.bannerMessage "[edgeXBuildGoParallel] Running Tests and Build..."
 
+    // fixes permissions issues due new Go 1.18 buildvcs checks
+    sh 'git config --global --add safe.directory $WORKSPACE'
+
     // TODO: This should go away after Kamakura, all repos now have a go.sum file.
     if(!fileExists('go.sum') && env.GO_VERSION =~ '1.16') {
         sh 'go mod tidy' // for Go 1.16


### PR DESCRIPTION
This PR is a fix for the issues we are seeing with golangci-lint and `go build` where the builds are failing with this new error (introduced in Go 1.18).

```
13:16:26  level=warning msg="[linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
13:16:26  cmd/core-command/main.go:1: : error obtaining VCS status: exit status 128
13:16:26  	Use -buildvcs=false to disable VCS stamping. (typecheck)
```

Due to different file permissions in the Jenkins `$WORKSPACE`, when Go runs:
```
13:40:29  git status --porcelain
```

It returns:
```
13:40:29  fatal: unsafe repository ('/w/workspace/dry_app-functions-sdk-go_PR-1150' is owned by someone else)
```
Which causes the Go command to fail with the error above. The suggested change is to add the workspace as a git "safe directory".

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/main/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
