### PR TITLE
feat: update to use new docker compose v2 syntax

### DIFF
--- a/src/test/groovy/edgeXDockerSpec.groovy
+++ b/src/test/groovy/edgeXDockerSpec.groovy
@@ -509,13 +509,6 @@ services:
             edgeXDocker.getBinding().setVariable('env', environmentVariables)
 
             getPipelineMock('docker.image')("nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest") >> explicitlyMockPipelineVariable('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest')
-
-            getPipelineMock('sh')([
-                returnStatus: true,
-                script: 'docker-compose build --help | grep parallel'
-            ]) >> {
-                0
-            }
         when:
             edgeXDocker.buildInParallel([
                 [image: 'image-1-go', dockerfile: 'cmd/image-1/Dockerfile'],
@@ -526,7 +519,7 @@ services:
                 _arguments[0][0] == 'BUILDER_BASE=ci-base-image'
             }
 
-            1 * getPipelineMock("sh").call('docker-compose -f ./docker-compose-build.yml build --parallel')
+            1 * getPipelineMock("sh").call('docker compose -f ./docker-compose-build.yml build --parallel')
 
             1 * getPipelineMock("writeFile").call(['file': './docker-compose-build.yml', 'text': '''
 version: '3.7'
@@ -568,13 +561,6 @@ services:
             edgeXDocker.getBinding().setVariable('env', environmentVariables)
 
             getPipelineMock('docker.image')("nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose-arm64:latest") >> explicitlyMockPipelineVariable('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose-arm64:latest')
-
-            getPipelineMock('sh')([
-                returnStatus: true,
-                script: 'docker-compose build --help | grep parallel'
-            ]) >> {
-                0
-            }
         when:
             edgeXDocker.buildInParallel([
                 [image: 'image-1-go', dockerfile: 'cmd/image-1/Dockerfile'],
@@ -585,7 +571,7 @@ services:
                 _arguments[0][0] == 'BUILDER_BASE=ci-base-image-arm64'
             }
 
-            1 * getPipelineMock("sh").call('docker-compose -f ./docker-compose-build.yml build --parallel')
+            1 * getPipelineMock("sh").call('docker compose -f ./docker-compose-build.yml build --parallel')
 
             1 * getPipelineMock("writeFile").call(['file': './docker-compose-build.yml', 'text': '''
 version: '3.7'
@@ -615,25 +601,6 @@ services:
         - BUILDER_BASE
     image: docker-image-2-go-arm64
 '''])
-    }
-
-    def "Test buildInParallel [Should] throw error [When] docker-compose does not support parallel" () {
-        setup:
-            getPipelineMock('docker.image')("nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest") >> explicitlyMockPipelineVariable('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest')
-
-            getPipelineMock('sh')([
-                returnStatus: true,
-                script: 'docker-compose build --help | grep parallel'
-            ]) >> {
-                1
-            }
-        when:
-            edgeXDocker.buildInParallel([
-                [image: 'image-1-go', dockerfile: 'cmd/image-1/Dockerfile'],
-                [image: 'image-2-go', dockerfile: 'cmd/image-2/Dockerfile']
-            ], 'docker-', 'ci-base-image')
-        then:
-            1 * getPipelineMock('error').call('[edgeXDocker] --parallel build is not supported in this version of docker-compose')
     }
 
     def "Test multiArch [Should] retag and create image manifest [When] called with nexus image" () {

--- a/vars/edgeXBuildGoParallel.groovy
+++ b/vars/edgeXBuildGoParallel.groovy
@@ -19,7 +19,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 /**
  # edgeXBuildGoParallel
 
- Shared Library to build Go projects and Docker images in parallel. Utilizes docker-compose --parallel to build Docker images found in the workspace. Currently only used for the **edgex-go** mono-repo.
+ Shared Library to build Go projects and Docker images in parallel. Utilizes docker compose --parallel to build Docker images found in the workspace. Currently only used for the **edgex-go** mono-repo.
 
  ## Overview
 


### PR DESCRIPTION
Update `docker-compose` references to use new docker compose v2. Parallel is supported by default in docker-compose v2 so I removed the check for parallel.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
