### PR TITLE
feat: create vanity tag on release

### DIFF
--- a/resources/update-named-tag.sh
+++ b/resources/update-named-tag.sh
@@ -23,18 +23,18 @@ response=$(echo "$response" | tr '[:upper:]' '[:lower:]')    # tolower
 
 if [[ "$response" =~ ^(yes|y)$ ]]; then
   echo "Getting latest changes from origin"
-  git fetch origin
+  set -x ; git fetch origin; set +x
 
   echo "Checking to see if tagged version [${taggedVersion}] exists on remote..."
-  if git tag | grep -w "${taggedVersion}" ; then
+  if git tag --list | grep -w "${taggedVersion}" ; then
     echo "Tagged version exists. Continuing..."
   else
     echo "Tagged version does not exist. Exiting..."
     exit 1
   fi
 
-  echo "Deleting local and remote tags..."
-  if git tag | grep "${tagName}" ; then
+  if git tag --list | grep "${tagName}$" ; then
+    echo "Deleting local and remote tags..."
     git tag -d "${tagName}"
     git push --delete origin "${tagName}"
 

--- a/src/test/groovy/edgeXReleaseSpec.groovy
+++ b/src/test/groovy/edgeXReleaseSpec.groovy
@@ -20,6 +20,7 @@ public class EdgeXReleaseSpec extends JenkinsPipelineSpecification {
         explicitlyMockPipelineVariable('edgeXReleaseDockerImage')
         explicitlyMockPipelineVariable('edgeXReleaseGitHubAssets')
         explicitlyMockPipelineVariable('edgeXReleaseOpenApi')
+        explicitlyMockPipelineVariable('edgeXUpdateNamedTag')
     }
 
     def "Test collectReleaseYamlFiles [Should] return instance of java.util.ArrayList of size 2 [When] called with no parameters and two changed files" () {

--- a/vars/edgeXRelease.groovy
+++ b/vars/edgeXRelease.groovy
@@ -113,7 +113,23 @@ def parallelStepFactoryTransform(step) {
                         }
                     }
                 } finally {
-                    stage("Bump Semver"){
+                    stage("Bump Semver") {
+                        def createVanityTag = edgex.defaultTrue(step.createVanityTag)
+
+                        if(createVanityTag) {
+                            // update vanity tag if artifact was built successfully
+                            def minorVersion = "v${step.version.split("\\.")[0..1].join('.')}"
+                            if(edgex.isDryRun()) {
+                                echo """dir('${dir.name}') {"
+                                    ./update-named-tag.sh v${step.version} ${minorVersion}"
+                                }"""
+                            } else {
+                                dir(step.name) {
+                                    edgeXUpdateNamedTag(step.version, minorVersion)
+                                }
+                            }
+                        }
+
                         edgeXReleaseGitTag(step, [credentials: "edgex-jenkins-ssh", bump: true, tag: false])
                     }
                 }


### PR DESCRIPTION
### Functional Test: Release v5.1.4
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/job/PR-359/20/console

### Functional Test: Release v5.1.5
https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/job/PR-359/21/console

In both functional tests the v5.1 tag was created and pointed to the released version.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number: #435 

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
