### PR TITLE
fix: Not run arm64 stage for go-mod and go-sdk repositories

### DIFF
--- a/vars/edgeXBuildGoApp.groovy
+++ b/vars/edgeXBuildGoApp.groovy
@@ -301,6 +301,7 @@ def call(config) {
                                 when {
                                     beforeAgent true
                                     expression { !env.GIT_BRANCH.startsWith('PR-') }
+                                    expression { !(env.PROJECT =~ /go-mod|sdk/) }
                                     expression { edgex.nodeExists(config, 'arm64') }
                                 }
                                 agent {


### PR DESCRIPTION
Not run arm64 stage for go-mod and go-sdk repositories

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
