### PR TITLE
ci: disable building multi-arch nexus docker images

### DIFF
--- a/vars/edgeXDocker.groovy
+++ b/vars/edgeXDocker.groovy
@@ -156,19 +156,19 @@ def generateServiceYaml(serviceName, imageNamePrefix, dockerFile, labels, arch =
     image: ${imageNamePrefix}${serviceName}${imageNameSuffix}"""
 }
 
-// push single docker image with tags. Also create and push multi-architecture images based on the pushed images.
+// push single docker image with tags.
 def push(dockerImage, latest = true, nexusRepo = 'staging', tags = null) {
     def pushedImages = []
 
     pushedImages = pushDockerImage(dockerImage, latest, nexusRepo, tags)
 
-    pushMultiArchImages(pushedImages)
+    // pushMultiArchImages(pushedImages)
 
     pushedImages
 }
 
 /*
- * push all input docker images. Also create and push multi-architecture images based on the pushed images.
+ * push all input docker images.
  *
  * @param dockerImages = [
        [image: 'docker-example', dockerfile: '/path/to/dockerfile'],
@@ -194,7 +194,7 @@ def pushAll(dockerImages, latest = true, nexusRepo = 'staging', arch = null) {
         }
     }
 
-    pushMultiArchImages(allPushedImages)
+    // pushMultiArchImages(allPushedImages)
 
     pushedImages
 }
@@ -254,6 +254,8 @@ ${tags.join('\n')}
     taggedImages
 }
 
+// DISABLED: current dev build infrastructure doesn't support docker manifest or docker buildx with arm64 build
+// edgeXBuildMultiArch builds multi-arch images, but fails with "exec format error" on startup
 // create and push multi-architecture docker images based on the input dockerImages
 def pushMultiArchImages(dockerImages){
     def multiArchImages = []


### PR DESCRIPTION
current dev build infrastructure doesn't support docker manifest or docker buildx with arm64 build docker manifest fails with permission denied
docker buildx only runs on CentOS 7, but that version is too outdated. The build completes but fails with "exec format error" on startup.

close https://github.com/edgexfoundry/edgex-global-pipelines/issues/477

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
