### PR TITLE
docs: Update gh-pages publish to detect new version dirs

### DIFF
--- a/resources/github-pages-publish.sh
+++ b/resources/github-pages-publish.sh
@@ -9,10 +9,15 @@ cp -rlf docs/* .
 rm -rf docs
 ls -al .
 
-changesDetected=$(git diff-index --quiet HEAD --)
+git diff-index --quiet HEAD --
+trackedChanged=$?
 
-if [ $? -ne 0 ]; then
-  echo "[edgeXGHPagesPublish] We have detected there are changes to commit: $changesDetected"
+# git diff-index HEAD only sees tracked files; catch a brand-new untracked
+# version directory (e.g. 4.0.2/) that a version-bump publish adds on its own
+untrackedVersionDirs=$(git ls-files --others --exclude-standard --directory | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?/' || true)
+
+if [ "$trackedChanged" -ne 0 ] || [ -n "$untrackedVersionDirs" ]; then
+  echo "[edgeXGHPagesPublish] Detected changes to commit (trackedChanged=$trackedChanged, untrackedVersionDirs=$untrackedVersionDirs)"
   git config --global user.email "jenkins@edgexfoundry.org"
   git config --global user.name "EdgeX Jenkins"
   git add .


### PR DESCRIPTION
git diff-index --quiet HEAD -- only reports tracked files. Earlier new version dirs (e.g. 4.1, 3.2) were still published because the same run also changed the tracked versions.json, which tripped the check and let git add . sweep in the new untracked dir.

For 4.0.2 the versions.json update landed in a separate commit, so the publish saw only a brand-new untracked 4.0.2/ dir, detected no change, and skipped the commit and push.

Now also detect an untracked version directory and commit when either tracked changes or a new version dir is present.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
